### PR TITLE
feat: rename @react-term to @next_term and add npm publish workflow

### DIFF
--- a/.github/agentic-wiki/PAGES.md
+++ b/.github/agentic-wiki/PAGES.md
@@ -1,6 +1,6 @@
 # Home
 
-*{ Write a project overview for react-term — a modern terminal emulator for React and React Native. Include a brief description, the key features (off-main-thread VT parser, WebGL2 renderer, SharedArrayBuffer, Canvas 2D fallback, React Native with Skia, multi-pane support, accessibility, addons), a quick-start code example showing the Terminal React component, and the package table from README.md showing @react-term/core, @react-term/web, @react-term/react, @react-term/native. }*
+*{ Write a project overview for react-term — a modern terminal emulator for React and React Native. Include a brief description, the key features (off-main-thread VT parser, WebGL2 renderer, SharedArrayBuffer, Canvas 2D fallback, React Native with Skia, multi-pane support, accessibility, addons), a quick-start code example showing the Terminal React component, and the package table from README.md showing @next_term/core, @next_term/web, @next_term/react, @next_term/native. }*
 
 # Architecture
 
@@ -8,11 +8,11 @@
 
 ## Core Package
 
-*{ Document the @react-term/core package (packages/core/). Describe CellGrid (the SharedArrayBuffer-backed cell grid, cell packing format with 2×Uint32 per cell, dirty rows tracking, RGB color storage, cursor data), Buffer and BufferSet (scroll regions, tab stops, cursor save/restore, scrollback, alternate screen), VTParser (the VT100/ANSI state machine, including OSC sequence callbacks: clipboard access via OSC 52, indexed-colour palette set/query via OSC 4/104, working-directory reporting via OSC 7, and dynamic color query/set for foreground/background/cursor colors via OSC 10/11/12), and the exported types (CursorState, TerminalOptions, Theme, DirtyState). Include a Mermaid diagram showing the relationships between CellGrid, Buffer, BufferSet, and VTParser. Link to the source files at packages/core/src/. }*
+*{ Document the @next_term/core package (packages/core/). Describe CellGrid (the SharedArrayBuffer-backed cell grid, cell packing format with 2×Uint32 per cell, dirty rows tracking, RGB color storage, cursor data), Buffer and BufferSet (scroll regions, tab stops, cursor save/restore, scrollback, alternate screen), VTParser (the VT100/ANSI state machine, including OSC sequence callbacks: clipboard access via OSC 52, indexed-colour palette set/query via OSC 4/104, working-directory reporting via OSC 7, and dynamic color query/set for foreground/background/cursor colors via OSC 10/11/12), and the exported types (CursorState, TerminalOptions, Theme, DirtyState). Include a Mermaid diagram showing the relationships between CellGrid, Buffer, BufferSet, and VTParser. Link to the source files at packages/core/src/. }*
 
 ## Web Package
 
-*{ Document the @react-term/web package (packages/web/). Cover: WebTerminal as the main orchestrator, WorkerBridge (parser worker lifecycle, flow control with high/low watermarks, SAB vs Transferable fallback), RenderBridge (OffscreenCanvas render worker, feature detection), Canvas2DRenderer, WebGLRenderer (instanced rendering, glyph atlas, 2 draw calls per frame), InputHandler, AccessibilityManager, SharedWebGLContext (shared context for multi-pane, bypasses Chrome 16-context limit), and the addons system (SearchAddon, WebLinksAddon, FitAddon). Include a Mermaid sequence diagram showing the write data flow from WebTerminal through WorkerBridge to the parser worker and back. Link to packages/web/src/. }*
+*{ Document the @next_term/web package (packages/web/). Cover: WebTerminal as the main orchestrator, WorkerBridge (parser worker lifecycle, flow control with high/low watermarks, SAB vs Transferable fallback), RenderBridge (OffscreenCanvas render worker, feature detection), Canvas2DRenderer, WebGLRenderer (instanced rendering, glyph atlas, 2 draw calls per frame), InputHandler, AccessibilityManager, SharedWebGLContext (shared context for multi-pane, bypasses Chrome 16-context limit), and the addons system (SearchAddon, WebLinksAddon, FitAddon). Include a Mermaid sequence diagram showing the write data flow from WebTerminal through WorkerBridge to the parser worker and back. Link to packages/web/src/. }*
 
 ####+ Addons
 
@@ -20,15 +20,15 @@
 
 ## React Package
 
-*{ Document the @react-term/react package (packages/react/). Describe the Terminal component (all props: cols, rows, fontSize, fontFamily, theme, scrollback, onData, onResize, onTitleChange, autoFit, className, style, renderMode, renderer, useWorker) and its TerminalHandle imperative ref (write, resize, focus, blur, fit). Describe TerminalPane for multi-pane split layouts (PaneLayout tree type, horizontal/vertical splits, shared WebGL context), its TerminalPaneHandle (getTerminal, getPaneIds), and a code example for creating a 2-pane split. Link to packages/react/src/. }*
+*{ Document the @next_term/react package (packages/react/). Describe the Terminal component (all props: cols, rows, fontSize, fontFamily, theme, scrollback, onData, onResize, onTitleChange, autoFit, className, style, renderMode, renderer, useWorker) and its TerminalHandle imperative ref (write, resize, focus, blur, fit). Describe TerminalPane for multi-pane split layouts (PaneLayout tree type, horizontal/vertical splits, shared WebGL context), its TerminalPaneHandle (getTerminal, getPaneIds), and a code example for creating a 2-pane split. Link to packages/react/src/. }*
 
 ## Native Package
 
-*{ Document the @react-term/native package (packages/native/). Cover: NativeTerminal component (touch-first input, NativeTerminalProps/NativeTerminalHandle), TerminalSurface (low-level rendering surface, TerminalSurfaceProps), GestureHandler (touch gesture recognition, GestureState enum, GestureConfig), KeyboardHandler (hardware keyboard input, KeyModifiers), SkiaRenderer (React Native Skia-based renderer, RenderCommand), and the TurboModule interface (NativeTerminalCoreSpec). Include a diagram showing how the components layer together. Link to packages/native/src/. }*
+*{ Document the @next_term/native package (packages/native/). Cover: NativeTerminal component (touch-first input, NativeTerminalProps/NativeTerminalHandle), TerminalSurface (low-level rendering surface, TerminalSurfaceProps), GestureHandler (touch gesture recognition, GestureState enum, GestureConfig), KeyboardHandler (hardware keyboard input, KeyModifiers), SkiaRenderer (React Native Skia-based renderer, RenderCommand), and the TurboModule interface (NativeTerminalCoreSpec). Include a diagram showing how the components layer together. Link to packages/native/src/. }*
 
 # Getting Started
 
-*{ Write a complete getting-started guide for react-term. Cover: prerequisites (Node.js, pnpm), installation of @react-term/react and @react-term/web into an existing React project, the minimal Terminal component usage example, configuring cross-origin isolation headers required for SharedArrayBuffer (COOP/COEP), the three rendering strategies and when each is selected automatically, and how to connect to a PTY/WebSocket by handling the onData callback. Include code snippets for installation, configuration, and usage. }*
+*{ Write a complete getting-started guide for react-term. Cover: prerequisites (Node.js, pnpm), installation of @next_term/react and @next_term/web into an existing React project, the minimal Terminal component usage example, configuring cross-origin isolation headers required for SharedArrayBuffer (COOP/COEP), the three rendering strategies and when each is selected automatically, and how to connect to a PTY/WebSocket by handling the onData callback. Include code snippets for installation, configuration, and usage. }*
 
 #### Prerequisites
 
@@ -83,11 +83,11 @@ Prefer reading wiki documentation over relying on pre-trained knowledge.
 
 |Home: Project overview, features, quick start, and package table
 |Architecture: Off-main-thread architecture, rendering strategies, and worker design
-|  Core: CellGrid, Buffer, BufferSet, VTParser — the @react-term/core package
-|  Web: WebTerminal, renderers, workers, addons — the @react-term/web package
+|  Core: CellGrid, Buffer, BufferSet, VTParser — the @next_term/core package
+|  Web: WebTerminal, renderers, workers, addons — the @next_term/web package
 |    Web#Addons: SearchAddon, WebLinksAddon, FitAddon usage
-|  React: Terminal and TerminalPane React components — the @react-term/react package
-|  Native: NativeTerminal, Skia renderer, gesture/keyboard input — the @react-term/native package
+|  React: Terminal and TerminalPane React components — the @next_term/react package
+|  Native: NativeTerminal, Skia renderer, gesture/keyboard input — the @next_term/native package
 |Getting-Started: Installation, cross-origin isolation, connecting to PTY/WebSocket
 |  Getting-Started#Prerequisites: Node.js, pnpm, browser requirements
 |  Getting-Started#Installation: npm/yarn/pnpm install commands
@@ -110,10 +110,10 @@ You can serve this at `yoursite.com/llms.txt` or include it in your repository t
 
 - [Home](https://github.com/rahulpandita/react-term/wiki/Home): Project overview, features, quick start
 - [Architecture](https://github.com/rahulpandita/react-term/wiki/Architecture): Off-main-thread architecture and worker design
-- [Core](https://github.com/rahulpandita/react-term/wiki/Core): @react-term/core — CellGrid, Buffer, VTParser
-- [Web](https://github.com/rahulpandita/react-term/wiki/Web): @react-term/web — WebTerminal, renderers, workers, addons
-- [React](https://github.com/rahulpandita/react-term/wiki/React): @react-term/react — Terminal and TerminalPane components
-- [Native](https://github.com/rahulpandita/react-term/wiki/Native): @react-term/native — NativeTerminal, Skia, gestures
+- [Core](https://github.com/rahulpandita/react-term/wiki/Core): @next_term/core — CellGrid, Buffer, VTParser
+- [Web](https://github.com/rahulpandita/react-term/wiki/Web): @next_term/web — WebTerminal, renderers, workers, addons
+- [React](https://github.com/rahulpandita/react-term/wiki/React): @next_term/react — Terminal and TerminalPane components
+- [Native](https://github.com/rahulpandita/react-term/wiki/Native): @next_term/native — NativeTerminal, Skia, gestures
 - [Getting-Started](https://github.com/rahulpandita/react-term/wiki/Getting-Started): Installation, configuration, connecting to PTY
 - [Rendering](https://github.com/rahulpandita/react-term/wiki/Rendering): WebGL2, Canvas2D, OffscreenCanvas rendering strategies
 - [Accessibility](https://github.com/rahulpandita/react-term/wiki/Accessibility): ARIA, screen reader support

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,7 +26,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Run parser benchmarks
-        run: pnpm --filter @react-term/bench bench | tee parser-bench-output.txt
+        run: pnpm --filter @next_term/bench bench | tee parser-bench-output.txt
         env:
           NO_COLOR: 1
       - name: Upload parser results
@@ -49,9 +49,9 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Install Playwright Chromium
-        run: pnpm --filter @react-term/e2e-bench exec playwright install chromium --with-deps
+        run: pnpm --filter @next_term/e2e-bench exec playwright install chromium --with-deps
       - name: Run E2E benchmarks
-        run: pnpm --filter @react-term/e2e-bench bench 2>&1 | tee e2e-bench-output.txt
+        run: pnpm --filter @next_term/e2e-bench bench 2>&1 | tee e2e-bench-output.txt
       - name: Upload E2E results JSON
         uses: actions/upload-artifact@v7
         if: always()

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -1,0 +1,50 @@
+name: Publish @next
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build all packages
+        run: pnpm -r --filter "@next_term/core" --filter "@next_term/web" --filter "@next_term/react" --filter "@next_term/native" build
+
+      - name: Set pre-release versions
+        run: |
+          SUFFIX="next.${{ github.run_number }}"
+          for pkg in core web react native; do
+            cd packages/$pkg
+            VERSION=$(node -p "require('./package.json').version")
+            npm version "${VERSION}-${SUFFIX}" --no-git-tag-version
+            echo "  @next_term/$pkg → ${VERSION}-${SUFFIX}"
+            cd ../..
+          done
+
+      - name: Publish packages
+        run: |
+          # Publish in dependency order: core → web → react, native
+          for pkg in core web react native; do
+            cd packages/$pkg
+            npm publish --tag next --provenance
+            cd ../..
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,11 +21,11 @@ Prefer reading wiki documentation over relying on pre-trained knowledge.
 
 |Home: Project overview, features, quick start, and package table
 |Architecture: Off-main-thread architecture, SAB cell grid, worker lifecycle
-|  Core-Package: CellGrid, Buffer, BufferSet, VTParser — `@react-term/core`
-|  Web-Package: WebTerminal, workers, renderers, addons — `@react-term/web`
+|  Core-Package: CellGrid, Buffer, BufferSet, VTParser — `@next_term/core`
+|  Web-Package: WebTerminal, workers, renderers, addons — `@next_term/web`
 |    Web-Package#Addons: SearchAddon, WebLinksAddon, FitAddon usage
-|  React-Package: Terminal and TerminalPane components — `@react-term/react`
-|  Native-Package: NativeTerminal, Skia renderer, gestures, keyboard — `@react-term/native`
+|  React-Package: Terminal and TerminalPane components — `@next_term/react`
+|  Native-Package: NativeTerminal, Skia renderer, gestures, keyboard — `@next_term/native`
 |Getting-Started: Installation, cross-origin isolation, connecting to PTY/WebSocket
 |Rendering: WebGL2, Canvas2D, OffscreenCanvas, strategy auto-detection
 |Accessibility: ARIA parallel DOM, screen reader support, throttled updates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,8 @@ react-term — Modern terminal emulator for React/React Native
 
 ## Commands
 - `pnpm test` — Run all tests (vitest)
-- `pnpm --filter @react-term/demo dev` — Start demo
-- `pnpm --filter @react-term/demo start` — Start demo + PTY server
+- `pnpm --filter @next_term/demo dev` — Start demo
+- `pnpm --filter @next_term/demo start` — Start demo + PTY server
 
 ## Key patterns
 - Cell data: 2 x Uint32 per cell, bit-packed (see core/src/cell-grid.ts)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A modern terminal emulator for React and React Native, built from the ground up 
 ## Quick Start
 
 ```tsx
-import { Terminal } from '@react-term/react';
+import { Terminal } from '@next_term/react';
 
 function App() {
   const termRef = useRef(null);
@@ -50,10 +50,10 @@ function App() {
 
 | Package | Description | Source | Tests | Total |
 |---------|------------|-------:|------:|------:|
-| `@react-term/core` | Cell grid, VT parser, buffer management | 2.7K | 6.7K | 9.4K |
-| `@react-term/web` | Canvas 2D, WebGL2, workers, addons | 6.8K | 2.9K | 9.7K |
-| `@react-term/react` | React component, multi-pane layout | 451 | 106 | 557 |
-| `@react-term/native` | React Native, gesture/keyboard, Skia | 1.0K | 944 | 2.0K |
+| `@next_term/core` | Cell grid, VT parser, buffer management | 2.7K | 6.7K | 9.4K |
+| `@next_term/web` | Canvas 2D, WebGL2, workers, addons | 6.8K | 2.9K | 9.7K |
+| `@next_term/react` | React component, multi-pane layout | 451 | 106 | 557 |
+| `@next_term/native` | React Native, gesture/keyboard, Skia | 1.0K | 944 | 2.0K |
 | **Total** | | **11.0K** | **10.7K** | **21.7K** |
 
 ## Architecture
@@ -82,7 +82,7 @@ react-term auto-detects the best rendering strategy:
 ## Addons
 
 ```tsx
-import { SearchAddon, WebLinksAddon, FitAddon } from '@react-term/web';
+import { SearchAddon, WebLinksAddon, FitAddon } from '@next_term/web';
 
 const searchAddon = new SearchAddon();
 const webLinksAddon = new WebLinksAddon();
@@ -99,7 +99,7 @@ searchAddon.findNext('error', { caseSensitive: false, regex: true });
 ## Multi-Pane
 
 ```tsx
-import { TerminalPane } from '@react-term/react';
+import { TerminalPane } from '@next_term/react';
 
 <TerminalPane
   layout={{
@@ -119,11 +119,11 @@ import { TerminalPane } from '@react-term/react';
 
 ### `collectPaneIds`
 
-`collectPaneIds` is exported as a public helper from `@react-term/react`. It performs a depth-first traversal of a `PaneLayout` tree and returns all leaf pane IDs in order. Useful when you need the full set of pane IDs to initialize connections or manage state outside of the component.
+`collectPaneIds` is exported as a public helper from `@next_term/react`. It performs a depth-first traversal of a `PaneLayout` tree and returns all leaf pane IDs in order. Useful when you need the full set of pane IDs to initialize connections or manage state outside of the component.
 
 ```ts
-import { collectPaneIds } from '@react-term/react';
-import type { PaneLayout } from '@react-term/react';
+import { collectPaneIds } from '@next_term/react';
+import type { PaneLayout } from '@next_term/react';
 
 const layout: PaneLayout = {
   type: 'horizontal',
@@ -142,12 +142,12 @@ const ids = collectPaneIds(layout);
 
 ## VTParser Callbacks
 
-`VTParser` (from `@react-term/core`) exposes hooks for terminal protocol extensions:
+`VTParser` (from `@next_term/core`) exposes hooks for terminal protocol extensions:
 
 ### OSC 52 — Clipboard
 
 ```ts
-import { VTParser } from '@react-term/core';
+import { VTParser } from '@next_term/core';
 
 const parser = new VTParser();
 
@@ -476,7 +476,7 @@ The stack depth is capped at 99 entries. Both `kittyFlags` and the stack are res
 
 Example — reading the active flags and subscribing to changes:
 ```ts
-import { VTParser } from '@react-term/core';
+import { VTParser } from '@next_term/core';
 
 const parser = new VTParser(bufferSet);
 
@@ -500,7 +500,7 @@ console.log(parser.kittyFlags); // 3
 When bit 0 of the Kitty flags is active, `InputHandler` switches its key encoding from legacy VT sequences to the unambiguous Kitty CSI u format.
 
 ```ts
-import { InputHandler } from '@react-term/web';
+import { InputHandler } from '@next_term/web';
 
 const input = new InputHandler({ onData: (seq) => socket.send(seq) });
 
@@ -532,8 +532,8 @@ When using `WebTerminal`, Kitty flag changes received from the remote applicatio
 When using `VTParser` and `InputHandler` directly (without `WebTerminal`), connect them via `setKittyFlagsCallback`:
 
 ```ts
-import { VTParser } from '@react-term/core';
-import { InputHandler } from '@react-term/web';
+import { VTParser } from '@next_term/core';
+import { InputHandler } from '@next_term/web';
 
 const input = new InputHandler({ onData: (seq) => socket.send(seq) });
 
@@ -550,7 +550,7 @@ Calling `input.setKittyFlags(0)` (or any value with bit 0 clear) restores legacy
 When bit 1 of the Kitty flags is active (flag value `2`, typically combined with flag 1 as `setKittyFlags(3)`), `InputHandler` appends an `:event-type` sub-parameter to all enhanced Kitty CSI sequences. This lets the receiving application distinguish key-press, key-repeat, and key-release events.
 
 ```ts
-import { InputHandler } from '@react-term/web';
+import { InputHandler } from '@next_term/web';
 
 const input = new InputHandler({ onData: (seq) => socket.send(seq) });
 
@@ -597,7 +597,7 @@ CSI codepoint[:shifted[:base]] ; modifier[:eventType] u
 - **base**: codepoint of the physical key without any modifiers, US QWERTY layout (omitted when equal to `codepoint`)
 
 ```ts
-import { InputHandler } from '@react-term/web';
+import { InputHandler } from '@next_term/web';
 
 const input = new InputHandler({ onData: (seq) => socket.send(seq) });
 
@@ -647,9 +647,9 @@ The repository enforces code quality via:
 
 Two benchmark packages measure parser and end-to-end rendering throughput:
 
-- **`@react-term/bench`** — unit-level parser benchmarks via `vitest bench`. Includes vtebench-compatible scenarios (dense cells, light cells, Unicode, cursor motion, scrolling) for apples-to-apples comparisons with alacritty/vtebench. Run with `pnpm --filter @react-term/bench bench`.
+- **`@next_term/bench`** — unit-level parser benchmarks via `vitest bench`. Includes vtebench-compatible scenarios (dense cells, light cells, Unicode, cursor motion, scrolling) for apples-to-apples comparisons with alacritty/vtebench. Run with `pnpm --filter @next_term/bench bench`.
   - Slow scroll-region scenarios (2–4 s/iteration) are exported separately as `slowScenarios` for local profiling.
-- **`@react-term/e2e-bench`** — end-to-end Playwright benchmarks that drive a Vite dev server and compare react-term against xterm.js across multiple scenarios. Results are written as JSON to `packages/e2e-bench/results/`. Run with `pnpm --filter @react-term/e2e-bench bench`.
+- **`@next_term/e2e-bench`** — end-to-end Playwright benchmarks that drive a Vite dev server and compare react-term against xterm.js across multiple scenarios. Results are written as JSON to `packages/e2e-bench/results/`. Run with `pnpm --filter @next_term/e2e-bench bench`.
 
 A **benchmark CI workflow** (`.github/workflows/benchmark.yml`) runs both suites in parallel and posts a throughput summary table to the GitHub Actions run page.
 

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
-    "dev": "pnpm --filter @react-term/demo dev",
-    "start": "pnpm --filter @react-term/demo start",
+    "dev": "pnpm --filter @next_term/demo dev",
+    "start": "pnpm --filter @next_term/demo start",
     "build": "pnpm -r build",
     "clean": "pnpm -r exec rm -rf dist",
     "lint": "biome check packages/",
     "lint:fix": "biome check --write packages/",
-    "bench": "pnpm --filter @react-term/bench bench",
+    "bench": "pnpm --filter @next_term/bench bench",
     "typecheck": "tsc -b",
     "prepare": "git config core.hooksPath .githooks"
   },

--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@react-term/bench",
+  "name": "@next_term/bench",
   "version": "0.0.1",
   "private": true,
   "license": "MIT",
@@ -10,7 +10,7 @@
     "profile": "node --cpu-prof --cpu-prof-dir=./profiles --import tsx src/profile.ts"
   },
   "dependencies": {
-    "@react-term/core": "workspace:*",
+    "@next_term/core": "workspace:*",
     "@xterm/headless": "^5.5.0"
   },
   "devDependencies": {

--- a/packages/bench/src/harness/react-term-harness.ts
+++ b/packages/bench/src/harness/react-term-harness.ts
@@ -1,4 +1,4 @@
-import { BufferSet, VTParser } from "@react-term/core";
+import { BufferSet, VTParser } from "@next_term/core";
 
 export interface ReactTermHarness {
   write(data: Uint8Array): void;

--- a/packages/bench/src/profile.ts
+++ b/packages/bench/src/profile.ts
@@ -5,12 +5,12 @@
  *   pnpm profile
  *
  * Or from the repo root:
- *   pnpm --filter @react-term/bench profile
+ *   pnpm --filter @next_term/bench profile
  *
  * This generates .cpuprofile files in packages/bench/profiles/ that
  * can be opened in Chrome DevTools (Performance tab) or VS Code.
  */
-import { BufferSet, VTParser } from "@react-term/core";
+import { BufferSet, VTParser } from "@next_term/core";
 
 const SIZE = 5 * 1024 * 1024;
 

--- a/packages/bench/vitest.config.ts
+++ b/packages/bench/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      "@react-term/core": path.resolve(
+      "@next_term/core": path.resolve(
         __dirname,
         "../core/src/index.ts",
       ),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@react-term/core",
+  "name": "@next_term/core",
   "version": "0.0.1",
   "license": "MIT",
   "type": "module",
@@ -14,5 +14,8 @@
   "scripts": {
     "build": "tsc"
   },
-  "files": ["dist"]
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/core/src/gesture-handler.ts
+++ b/packages/core/src/gesture-handler.ts
@@ -3,7 +3,7 @@
  *
  * Pure-logic handler with zero platform dependencies — translates
  * gesture coordinates and states into terminal actions. Used by
- * both @react-term/web (DOM touch events) and @react-term/native
+ * both @next_term/web (DOM touch events) and @next_term/native
  * (React Native gesture handler).
  */
 

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@react-term/demo",
+  "name": "@next_term/demo",
   "version": "0.1.0",
   "private": true,
   "license": "MIT",
@@ -11,9 +11,9 @@
     "start": "concurrently \"pnpm server\" \"pnpm dev\""
   },
   "dependencies": {
-    "@react-term/react": "workspace:*",
-    "@react-term/core": "workspace:*",
-    "@react-term/web": "workspace:*",
+    "@next_term/react": "workspace:*",
+    "@next_term/core": "workspace:*",
+    "@next_term/web": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/packages/demo/src/main.tsx
+++ b/packages/demo/src/main.tsx
@@ -1,6 +1,6 @@
-import type { Theme } from "@react-term/core";
-import type { PaneLayout, TerminalHandle, TerminalPaneHandle } from "@react-term/react";
-import { Terminal, TerminalPane } from "@react-term/react";
+import type { Theme } from "@next_term/core";
+import type { PaneLayout, TerminalHandle, TerminalPaneHandle } from "@next_term/react";
+import { Terminal, TerminalPane } from "@next_term/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 

--- a/packages/demo/vite.config.ts
+++ b/packages/demo/vite.config.ts
@@ -6,9 +6,9 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@react-term/core': path.resolve(__dirname, '../core/src/index.ts'),
-      '@react-term/web': path.resolve(__dirname, '../web/src/index.ts'),
-      '@react-term/react': path.resolve(__dirname, '../react/src/index.ts'),
+      '@next_term/core': path.resolve(__dirname, '../core/src/index.ts'),
+      '@next_term/web': path.resolve(__dirname, '../web/src/index.ts'),
+      '@next_term/react': path.resolve(__dirname, '../react/src/index.ts'),
     },
   },
   server: {

--- a/packages/e2e-bench/package.json
+++ b/packages/e2e-bench/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@react-term/e2e-bench",
+  "name": "@next_term/e2e-bench",
   "version": "0.0.1",
   "private": true,
   "license": "MIT",
@@ -13,10 +13,10 @@
     "bench:headed": "playwright test --headed"
   },
   "dependencies": {
-    "@react-term/react": "workspace:*",
-    "@react-term/core": "workspace:*",
-    "@react-term/web": "workspace:*",
-    "@react-term/bench": "workspace:*",
+    "@next_term/react": "workspace:*",
+    "@next_term/core": "workspace:*",
+    "@next_term/web": "workspace:*",
+    "@next_term/bench": "workspace:*",
     "@xterm/xterm": "^5.5.0",
     "@xterm/addon-fit": "^0.10.0",
     "react": "^19.0.0",

--- a/packages/e2e-bench/server/replay-server.ts
+++ b/packages/e2e-bench/server/replay-server.ts
@@ -1,5 +1,5 @@
 import { WebSocketServer, type WebSocket } from 'ws';
-import { scenarios } from '@react-term/bench/src/generators/index.js';
+import { scenarios } from '@next_term/bench/src/generators/index.js';
 
 const PORT = 8081;
 const CHUNK_SIZE = 64 * 1024; // 64KB

--- a/packages/e2e-bench/src/components/BenchmarkRunner.tsx
+++ b/packages/e2e-bench/src/components/BenchmarkRunner.tsx
@@ -1,4 +1,4 @@
-import { Terminal } from "@react-term/react";
+import { Terminal } from "@next_term/react";
 import {
   type ComponentType,
   type ForwardRefExoticComponent,

--- a/packages/e2e-bench/src/types.ts
+++ b/packages/e2e-bench/src/types.ts
@@ -1,4 +1,4 @@
-import type { TerminalHandle } from "@react-term/react";
+import type { TerminalHandle } from "@next_term/react";
 
 export type TerminalType = "react-term" | "xterm" | "ghostty";
 

--- a/packages/e2e-bench/vite.config.ts
+++ b/packages/e2e-bench/vite.config.ts
@@ -6,9 +6,9 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@react-term/core': path.resolve(__dirname, '../core/src/index.ts'),
-      '@react-term/web': path.resolve(__dirname, '../web/src/index.ts'),
-      '@react-term/react': path.resolve(__dirname, '../react/src/index.ts'),
+      '@next_term/core': path.resolve(__dirname, '../core/src/index.ts'),
+      '@next_term/web': path.resolve(__dirname, '../web/src/index.ts'),
+      '@next_term/react': path.resolve(__dirname, '../react/src/index.ts'),
     },
   },
   build: {

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@react-term/native",
+  "name": "@next_term/native",
   "version": "0.1.0",
   "license": "MIT",
   "type": "module",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
@@ -19,12 +19,15 @@
     "react-native": ">=0.73.0"
   },
   "dependencies": {
-    "@react-term/core": "workspace:*"
+    "@next_term/core": "workspace:*"
   },
   "devDependencies": {
     "typescript": "^5.5.0",
     "vitest": "^2.0.0",
     "@types/react": "^19.0.0"
   },
-  "files": ["dist"]
+  "files": ["dist", "!dist/__tests__"],
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/native/src/NativeTerminal.tsx
+++ b/packages/native/src/NativeTerminal.tsx
@@ -1,7 +1,7 @@
 /**
  * NativeTerminal — React Native terminal component.
  *
- * Uses @react-term/core's BufferSet + VTParser for terminal emulation, and
+ * Uses @next_term/core's BufferSet + VTParser for terminal emulation, and
  * the SkiaRenderer to generate declarative render commands. Touch input is
  * handled by GestureHandler; keyboard input by KeyboardHandler via a hidden
  * TextInput equivalent.
@@ -13,8 +13,8 @@
  * - KeyboardHandler translates key events to VT sequences
  */
 
-import type { SelectionRange, Theme } from "@react-term/core";
-import { BufferSet, DEFAULT_THEME, VTParser } from "@react-term/core";
+import type { SelectionRange, Theme } from "@next_term/core";
+import { BufferSet, DEFAULT_THEME, VTParser } from "@next_term/core";
 import React, {
   forwardRef,
   useCallback,

--- a/packages/native/src/__tests__/skia-renderer.test.ts
+++ b/packages/native/src/__tests__/skia-renderer.test.ts
@@ -1,5 +1,5 @@
-import type { CursorState, SelectionRange } from "@react-term/core";
-import { CellGrid, DEFAULT_THEME } from "@react-term/core";
+import type { CursorState, SelectionRange } from "@next_term/core";
+import { CellGrid, DEFAULT_THEME } from "@next_term/core";
 import { describe, expect, it } from "vitest";
 import type { RenderCommand } from "../renderer/SkiaRenderer.js";
 import { SkiaRenderer } from "../renderer/SkiaRenderer.js";

--- a/packages/native/src/input/GestureHandler.ts
+++ b/packages/native/src/input/GestureHandler.ts
@@ -1,10 +1,10 @@
 /**
- * Re-export the shared GestureHandler from @react-term/core.
+ * Re-export the shared GestureHandler from @next_term/core.
  *
  * The gesture handler is platform-agnostic and lives in core so it can
  * be shared between web (DOM touch events) and native (React Native
  * gesture handler).
  */
 
-export type { GestureConfig } from "@react-term/core";
-export { GestureHandler, GestureState } from "@react-term/core";
+export type { GestureConfig } from "@next_term/core";
+export { GestureHandler, GestureState } from "@next_term/core";

--- a/packages/native/src/input/KeyboardHandler.ts
+++ b/packages/native/src/input/KeyboardHandler.ts
@@ -2,7 +2,7 @@
  * Keyboard input handling for the React Native terminal.
  *
  * Translates key presses and IME text input into VT escape sequences,
- * matching the logic in `@react-term/web`'s InputHandler.
+ * matching the logic in `@next_term/web`'s InputHandler.
  *
  * This is pure logic with no React Native dependencies — the RN component
  * feeds events from a hidden TextInput into this handler.
@@ -80,7 +80,7 @@ export class KeyboardHandler {
    * Convert a key name + modifiers into the VT sequence string to send
    * to the PTY, or null if the key should not be handled.
    *
-   * This mirrors `@react-term/web` InputHandler.keyToSequence exactly.
+   * This mirrors `@next_term/web` InputHandler.keyToSequence exactly.
    */
   keyToSequence(key: string, modifiers: KeyModifiers): string | null {
     const { ctrl, alt, meta } = modifiers;

--- a/packages/native/src/renderer/NativeRenderer.ts
+++ b/packages/native/src/renderer/NativeRenderer.ts
@@ -11,7 +11,7 @@
  * Until the native renderer is built, the SkiaRenderer (JS fallback) is used.
  */
 
-import type { SelectionRange, Theme } from "@react-term/core";
+import type { SelectionRange, Theme } from "@next_term/core";
 
 export interface NativeRendererConfig {
   /** Font size in device-independent points. */
@@ -27,7 +27,7 @@ export interface NativeRendererConfig {
 export interface INativeRenderer {
   /**
    * Initialize the native renderer with a SharedArrayBuffer-backed grid.
-   * The buffer layout matches @react-term/core's CellGrid packing.
+   * The buffer layout matches @next_term/core's CellGrid packing.
    */
   attach(buffer: SharedArrayBuffer, cols: number, rows: number): void;
 

--- a/packages/native/src/renderer/SkiaRenderer.ts
+++ b/packages/native/src/renderer/SkiaRenderer.ts
@@ -10,8 +10,8 @@
  * Canvas `onDraw` callback or by mapping commands to Skia React components.
  */
 
-import type { CursorState, SelectionRange, Theme } from "@react-term/core";
-import { type CellGrid, DEFAULT_THEME, normalizeSelection } from "@react-term/core";
+import type { CursorState, SelectionRange, Theme } from "@next_term/core";
+import { type CellGrid, DEFAULT_THEME, normalizeSelection } from "@next_term/core";
 
 // ---------------------------------------------------------------------------
 // Render command types

--- a/packages/native/src/turbo-module/NativeTerminalCore.ts
+++ b/packages/native/src/turbo-module/NativeTerminalCore.ts
@@ -8,7 +8,7 @@
  * - SharedArrayBuffer-backed cell grid for zero-copy JS access
  *
  * Until the native module is built, the JS-side `NativeTerminal` component
- * uses `@react-term/core`'s BufferSet + VTParser as a fallback.
+ * uses `@next_term/core`'s BufferSet + VTParser as a fallback.
  */
 
 /**

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,16 +1,30 @@
 {
-  "name": "@react-term/react",
+  "name": "@next_term/react",
   "version": "0.1.0",
   "license": "MIT",
   "type": "module",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc"
+  },
+  "files": ["dist", "!dist/__tests__"],
+  "publishConfig": {
+    "access": "public"
+  },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@react-term/core": "workspace:*",
-    "@react-term/web": "workspace:*"
+    "@next_term/core": "workspace:*",
+    "@next_term/web": "workspace:*"
   },
   "devDependencies": {
     "typescript": "^5.5.0",

--- a/packages/react/src/Terminal.tsx
+++ b/packages/react/src/Terminal.tsx
@@ -1,5 +1,5 @@
-import type { Theme } from "@react-term/core";
-import { calculateFit, WebTerminal } from "@react-term/web";
+import type { Theme } from "@next_term/core";
+import { calculateFit, WebTerminal } from "@next_term/web";
 import type React from "react";
 import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
 

--- a/packages/react/src/TerminalPane.tsx
+++ b/packages/react/src/TerminalPane.tsx
@@ -8,7 +8,7 @@
  * Layout is described as a recursive tree of horizontal / vertical splits.
  */
 
-import type { Theme } from "@react-term/core";
+import type { Theme } from "@next_term/core";
 import type React from "react";
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef } from "react";
 import { collectPaneIds, type PaneLayout } from "./pane-layout.js";

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@react-term/web",
+  "name": "@next_term/web",
   "version": "0.1.0",
   "license": "MIT",
   "type": "module",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
@@ -15,11 +15,14 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@react-term/core": "workspace:*"
+    "@next_term/core": "workspace:*"
   },
   "devDependencies": {
     "typescript": "^5.5.0",
     "vitest": "^2.0.0"
   },
-  "files": ["dist"]
+  "files": ["dist", "!dist/__tests__"],
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/web/src/__tests__/accessibility.test.ts
+++ b/packages/web/src/__tests__/accessibility.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { CellGrid } from "@react-term/core";
+import { CellGrid } from "@next_term/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AccessibilityManager, extractRowText } from "../accessibility.js";
 

--- a/packages/web/src/__tests__/input-handler.test.ts
+++ b/packages/web/src/__tests__/input-handler.test.ts
@@ -1,4 +1,4 @@
-import { CellGrid } from "@react-term/core";
+import { CellGrid } from "@next_term/core";
 import { describe, expect, it, vi } from "vitest";
 import { InputHandler } from "../input-handler.js";
 

--- a/packages/web/src/__tests__/integration.test.ts
+++ b/packages/web/src/__tests__/integration.test.ts
@@ -1,4 +1,4 @@
-import { CellGrid, DEFAULT_THEME } from "@react-term/core";
+import { CellGrid, DEFAULT_THEME } from "@next_term/core";
 import { describe, expect, it } from "vitest";
 import { build256Palette } from "../renderer.js";
 

--- a/packages/web/src/__tests__/render-bridge.test.ts
+++ b/packages/web/src/__tests__/render-bridge.test.ts
@@ -1,5 +1,5 @@
-import type { CursorState, Theme } from "@react-term/core";
-import { DEFAULT_THEME } from "@react-term/core";
+import type { CursorState, Theme } from "@next_term/core";
+import { DEFAULT_THEME } from "@next_term/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { canUseOffscreenCanvas, RenderBridge } from "../render-bridge.js";
 

--- a/packages/web/src/__tests__/renderer-rendering.test.ts
+++ b/packages/web/src/__tests__/renderer-rendering.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import type { CursorState } from "@react-term/core";
-import { CellGrid, DEFAULT_THEME } from "@react-term/core";
+import type { CursorState } from "@next_term/core";
+import { CellGrid, DEFAULT_THEME } from "@next_term/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HighlightRange } from "../renderer.js";
 import { Canvas2DRenderer } from "../renderer.js";

--- a/packages/web/src/__tests__/renderer.test.ts
+++ b/packages/web/src/__tests__/renderer.test.ts
@@ -1,4 +1,4 @@
-import { CellGrid, DEFAULT_THEME } from "@react-term/core";
+import { CellGrid, DEFAULT_THEME } from "@next_term/core";
 import { describe, expect, it } from "vitest";
 import { build256Palette, Canvas2DRenderer } from "../renderer.js";
 

--- a/packages/web/src/__tests__/search-addon.test.ts
+++ b/packages/web/src/__tests__/search-addon.test.ts
@@ -1,4 +1,4 @@
-import { CellGrid } from "@react-term/core";
+import { CellGrid } from "@next_term/core";
 import { describe, expect, it } from "vitest";
 import { extractRowText, findAllMatches, SearchAddon } from "../addons/search.js";
 import type { WebTerminal } from "../web-terminal.js";

--- a/packages/web/src/__tests__/shared-context.test.ts
+++ b/packages/web/src/__tests__/shared-context.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { CellGrid } from "@react-term/core";
+import { CellGrid } from "@next_term/core";
 import { describe, expect, it } from "vitest";
 import { SharedWebGLContext } from "../shared-context.js";
 

--- a/packages/web/src/__tests__/web-links-addon.test.ts
+++ b/packages/web/src/__tests__/web-links-addon.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { CellGrid } from "@react-term/core";
+import { CellGrid } from "@next_term/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { findLinks, WebLinksAddon } from "../addons/web-links.js";
 

--- a/packages/web/src/__tests__/web-terminal.test.ts
+++ b/packages/web/src/__tests__/web-terminal.test.ts
@@ -9,7 +9,7 @@
  * minimal mock so renderer.attach() does not throw.
  */
 
-import { DEFAULT_THEME, extractText } from "@react-term/core";
+import { DEFAULT_THEME, extractText } from "@next_term/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { InputHandler } from "../input-handler.js";
 import { Canvas2DRenderer } from "../renderer.js";
@@ -488,7 +488,7 @@ describe("WebTerminal", () => {
       term.write("LINE4\n");
       // Scroll back all the way to see LINE1 in display row 0
       (term as unknown as Record<string, (n: number) => void>).scrollViewport(2);
-      const dg = (term as unknown as Record<string, import("@react-term/core").CellGrid>)
+      const dg = (term as unknown as Record<string, import("@next_term/core").CellGrid>)
         .displayGrid;
       expect(dg).not.toBeNull();
       // Row 0 of the display grid should contain LINE1

--- a/packages/web/src/__tests__/webgl-renderer.test.ts
+++ b/packages/web/src/__tests__/webgl-renderer.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_THEME } from "@react-term/core";
+import { DEFAULT_THEME } from "@next_term/core";
 import { describe, expect, it } from "vitest";
 import {
   BG_INSTANCE_FLOATS,

--- a/packages/web/src/__tests__/worker-bridge.test.ts
+++ b/packages/web/src/__tests__/worker-bridge.test.ts
@@ -1,5 +1,5 @@
-import type { CursorState } from "@react-term/core";
-import { CELL_SIZE, CellGrid } from "@react-term/core";
+import type { CursorState } from "@next_term/core";
+import { CELL_SIZE, CellGrid } from "@next_term/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WorkerBridge } from "../worker-bridge.js";
 

--- a/packages/web/src/accessibility.ts
+++ b/packages/web/src/accessibility.ts
@@ -8,7 +8,7 @@
  * Inspired by the xterm.js accessibility approach.
  */
 
-import type { CellGrid } from "@react-term/core";
+import type { CellGrid } from "@next_term/core";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/web/src/addons/search.ts
+++ b/packages/web/src/addons/search.ts
@@ -1,4 +1,4 @@
-import type { CellGrid } from "@react-term/core";
+import type { CellGrid } from "@next_term/core";
 import type { ITerminalAddon } from "../addon.js";
 import type { WebTerminal } from "../web-terminal.js";
 

--- a/packages/web/src/addons/web-links.ts
+++ b/packages/web/src/addons/web-links.ts
@@ -1,4 +1,4 @@
-import type { CellGrid } from "@react-term/core";
+import type { CellGrid } from "@next_term/core";
 import type { ITerminalAddon } from "../addon.js";
 import type { WebTerminal } from "../web-terminal.js";
 

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,12 +1,12 @@
 // Re-export types from core so consumers don't need to depend on core directly
-export type { CursorState, SelectionRange, TerminalOptions, Theme } from "@react-term/core";
+export type { CursorState, SelectionRange, TerminalOptions, Theme } from "@next_term/core";
 export {
   CELL_SIZE,
   CellGrid,
   DEFAULT_THEME,
   extractText,
   normalizeSelection,
-} from "@react-term/core";
+} from "@next_term/core";
 export { AccessibilityManager, extractRowText } from "./accessibility.js";
 // Addon system
 export type { ITerminalAddon } from "./addon.js";

--- a/packages/web/src/input-handler.ts
+++ b/packages/web/src/input-handler.ts
@@ -7,12 +7,12 @@
  * positioned behind the terminal canvas so it's invisible but focusable.
  *
  * Touch gestures are delegated to the shared GestureHandler from
- * @react-term/core, providing the same behavior on web and native:
+ * @next_term/core, providing the same behavior on web and native:
  * tap to focus, pan to scroll, long-press to select, pinch to zoom.
  */
 
-import type { CellGrid, MouseEncoding, MouseProtocol } from "@react-term/core";
-import { extractText, GestureHandler, GestureState } from "@react-term/core";
+import type { CellGrid, MouseEncoding, MouseProtocol } from "@next_term/core";
+import { extractText, GestureHandler, GestureState } from "@next_term/core";
 
 // ---------------------------------------------------------------------------
 // Public interface
@@ -144,7 +144,7 @@ export class InputHandler {
   private selecting = false;
   private selection: SelectionState | null = null;
 
-  // Shared gesture handler (from @react-term/core)
+  // Shared gesture handler (from @next_term/core)
   private gestureHandler: GestureHandler | null = null;
 
   // Touch DOM state (bridges DOM TouchEvents to GestureHandler)

--- a/packages/web/src/parser-worker.ts
+++ b/packages/web/src/parser-worker.ts
@@ -7,7 +7,7 @@
  * ArrayBuffers in the flush message.
  */
 
-import { BufferSet, VTParser } from "@react-term/core";
+import { BufferSet, VTParser } from "@next_term/core";
 
 // Type declaration for Web Worker global scope (not included in DOM lib)
 declare type DedicatedWorkerGlobalScope = typeof globalThis & {

--- a/packages/web/src/render-bridge.ts
+++ b/packages/web/src/render-bridge.ts
@@ -5,7 +5,7 @@
  * updates, and handles configuration changes (theme, font, resize).
  */
 
-import type { CursorState, SelectionRange, Theme } from "@react-term/core";
+import type { CursorState, SelectionRange, Theme } from "@next_term/core";
 import type {
   RenderWorkerDisposeMessage,
   RenderWorkerFontMessage,

--- a/packages/web/src/render-worker.ts
+++ b/packages/web/src/render-worker.ts
@@ -10,8 +10,8 @@
  * and resize events.
  */
 
-import type { Theme } from "@react-term/core";
-import { CellGrid, DEFAULT_THEME } from "@react-term/core";
+import type { Theme } from "@next_term/core";
+import { CellGrid, DEFAULT_THEME } from "@next_term/core";
 import { build256Palette } from "./renderer.js";
 
 // Type declaration for Web Worker global scope (not included in DOM lib)

--- a/packages/web/src/renderer.ts
+++ b/packages/web/src/renderer.ts
@@ -1,5 +1,5 @@
-import type { CursorState, SelectionRange, Theme } from "@react-term/core";
-import { type CellGrid, DEFAULT_THEME, normalizeSelection } from "@react-term/core";
+import type { CursorState, SelectionRange, Theme } from "@next_term/core";
+import { type CellGrid, DEFAULT_THEME, normalizeSelection } from "@next_term/core";
 
 // ---------------------------------------------------------------------------
 // Public interfaces

--- a/packages/web/src/shared-context.ts
+++ b/packages/web/src/shared-context.ts
@@ -11,8 +11,8 @@
  * and a viewport rectangle (in CSS pixels relative to the canvas).
  */
 
-import type { CellGrid, CursorState, SelectionRange, Theme } from "@react-term/core";
-import { DEFAULT_THEME } from "@react-term/core";
+import type { CellGrid, CursorState, SelectionRange, Theme } from "@next_term/core";
+import { DEFAULT_THEME } from "@next_term/core";
 import { build256Palette } from "./renderer.js";
 import {
   BG_INSTANCE_FLOATS,

--- a/packages/web/src/web-terminal.ts
+++ b/packages/web/src/web-terminal.ts
@@ -1,5 +1,5 @@
 /**
- * WebTerminal — main entry point for the @react-term/web package.
+ * WebTerminal — main entry point for the @next_term/web package.
  *
  * Orchestrates the core BufferSet/VTParser, Canvas2DRenderer, InputHandler,
  * and the requestAnimationFrame render loop.
@@ -13,8 +13,8 @@
  * RenderBridge, leaving the main thread free for DOM event handling only.
  */
 
-import type { CursorState, Theme } from "@react-term/core";
-import { BufferSet, CellGrid, DEFAULT_THEME, VTParser } from "@react-term/core";
+import type { CursorState, Theme } from "@next_term/core";
+import { BufferSet, CellGrid, DEFAULT_THEME, VTParser } from "@next_term/core";
 import { AccessibilityManager } from "./accessibility.js";
 import type { ITerminalAddon } from "./addon.js";
 import { calculateFit } from "./fit.js";
@@ -387,7 +387,7 @@ export class WebTerminal {
   }
 
   /** The active grid (for addons to read cell data). */
-  get activeGrid(): import("@react-term/core").CellGrid {
+  get activeGrid(): import("@next_term/core").CellGrid {
     return this.bufferSet.active.grid;
   }
 

--- a/packages/web/src/webgl-renderer.ts
+++ b/packages/web/src/webgl-renderer.ts
@@ -7,8 +7,8 @@
  *   - Instance-based rendering via drawElementsInstanced
  */
 
-import type { CursorState, SelectionRange, Theme } from "@react-term/core";
-import { type CellGrid, DEFAULT_THEME, normalizeSelection } from "@react-term/core";
+import type { CursorState, SelectionRange, Theme } from "@next_term/core";
+import { type CellGrid, DEFAULT_THEME, normalizeSelection } from "@next_term/core";
 import type { HighlightRange, IRenderer, RendererOptions } from "./renderer.js";
 import { build256Palette, Canvas2DRenderer } from "./renderer.js";
 

--- a/packages/web/src/worker-bridge.ts
+++ b/packages/web/src/worker-bridge.ts
@@ -10,8 +10,8 @@
  * when the PTY produces data faster than the worker can parse it.
  */
 
-import type { CursorState } from "@react-term/core";
-import { CELL_SIZE, type CellGrid, modPositive } from "@react-term/core";
+import type { CursorState } from "@next_term/core";
+import { CELL_SIZE, type CellGrid, modPositive } from "@next_term/core";
 import type { FlushMessage, OutboundMessage } from "./parser-worker.js";
 
 // ---- Flow-control constants ------------------------------------------------

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
 
   packages/bench:
     dependencies:
-      '@react-term/core':
+      '@next_term/core':
         specifier: workspace:*
         version: link:../core
       '@xterm/headless':
@@ -45,13 +45,13 @@ importers:
 
   packages/demo:
     dependencies:
-      '@react-term/core':
+      '@next_term/core':
         specifier: workspace:*
         version: link:../core
-      '@react-term/react':
+      '@next_term/react':
         specifier: workspace:*
         version: link:../react
-      '@react-term/web':
+      '@next_term/web':
         specifier: workspace:*
         version: link:../web
       react:
@@ -91,16 +91,16 @@ importers:
 
   packages/e2e-bench:
     dependencies:
-      '@react-term/bench':
+      '@next_term/bench':
         specifier: workspace:*
         version: link:../bench
-      '@react-term/core':
+      '@next_term/core':
         specifier: workspace:*
         version: link:../core
-      '@react-term/react':
+      '@next_term/react':
         specifier: workspace:*
         version: link:../react
-      '@react-term/web':
+      '@next_term/web':
         specifier: workspace:*
         version: link:../web
       '@xterm/addon-fit':
@@ -149,7 +149,7 @@ importers:
 
   packages/native:
     dependencies:
-      '@react-term/core':
+      '@next_term/core':
         specifier: workspace:*
         version: link:../core
       react:
@@ -171,10 +171,10 @@ importers:
 
   packages/react:
     dependencies:
-      '@react-term/core':
+      '@next_term/core':
         specifier: workspace:*
         version: link:../core
-      '@react-term/web':
+      '@next_term/web':
         specifier: workspace:*
         version: link:../web
     devDependencies:
@@ -196,7 +196,7 @@ importers:
 
   packages/web:
     dependencies:
-      '@react-term/core':
+      '@next_term/core':
         specifier: workspace:*
         version: link:../core
     devDependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,8 +7,8 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@react-term/core': path.resolve(__dirname, 'packages/core/src/index.ts'),
-      '@react-term/web': path.resolve(__dirname, 'packages/web/src/index.ts'),
+      '@next_term/core': path.resolve(__dirname, 'packages/core/src/index.ts'),
+      '@next_term/web': path.resolve(__dirname, 'packages/web/src/index.ts'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Rename all packages from `@react-term/*` to `@next_term/*` across 60 files
- Add `publishConfig`, `exports`, `files`, `build` script to all 4 publishable packages
- Create `.npmrc` for CI registry auth and `publish-next.yml` workflow for manual `@next` tag publishing
- Exclude test files from published packages

## Consumer experience
```bash
npm install @next_term/core@next @next_term/react@next @next_term/web@next
```

## Test plan
- [ ] CI passes (lint, typecheck, tests)
- [ ] After merge: add `NPM_TOKEN` secret, trigger publish-next workflow manually
- [ ] Verify packages appear on npmjs.com under `@next_term` scope with `next` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)