### PR TITLE
feat(web): add fontWeight and fontWeightBold options

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"ae96c0fc-c8d5-468a-8801-5c82d92203e9","pid":92639,"acquiredAt":1775334096712}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"ae96c0fc-c8d5-468a-8801-5c82d92203e9","pid":92639,"acquiredAt":1775334096712}

--- a/.gitignore
+++ b/.gitignore
@@ -148,4 +148,4 @@ vite.config.ts.timestamp-*
 
 # Playwright MCP
 .playwright-mcp/
-*.png
+*.png.claude/scheduled_tasks.lock

--- a/packages/react/src/Terminal.tsx
+++ b/packages/react/src/Terminal.tsx
@@ -9,6 +9,10 @@ export interface TerminalProps {
   rows?: number;
   fontSize?: number;
   fontFamily?: string;
+  /** CSS font-weight for normal text (default: 400). */
+  fontWeight?: number;
+  /** CSS font-weight for bold text (default: 700). */
+  fontWeightBold?: number;
   theme?: Partial<Theme>;
   scrollback?: number;
   onData?: (data: Uint8Array) => void;
@@ -43,6 +47,8 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     rows = 24,
     fontSize = 16,
     fontFamily = "'Courier New', monospace",
+    fontWeight,
+    fontWeightBold,
     theme,
     scrollback = 1000,
     onData,
@@ -119,6 +125,8 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       rows,
       fontSize,
       fontFamily,
+      fontWeight,
+      fontWeightBold,
       theme,
       scrollback,
       renderMode,
@@ -142,6 +150,8 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     cols,
     fontFamily,
     fontSize,
+    fontWeight,
+    fontWeightBold,
     paneId,
     renderMode,
     rendererProp,
@@ -162,9 +172,9 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
   // Update font when it changes
   useEffect(() => {
     if (termRef.current) {
-      termRef.current.setFont(fontSize, fontFamily);
+      termRef.current.setFont(fontSize, fontFamily, fontWeight, fontWeightBold);
     }
-  }, [fontSize, fontFamily]);
+  }, [fontSize, fontFamily, fontWeight, fontWeightBold]);
 
   // AutoFit: observe container size via ResizeObserver, debounced with rAF.
   // Also listen to visualViewport resize for iOS keyboard show/hide.

--- a/packages/react/src/TerminalPane.tsx
+++ b/packages/react/src/TerminalPane.tsx
@@ -29,6 +29,8 @@ export interface TerminalPaneProps {
   theme?: Partial<Theme>;
   fontSize?: number;
   fontFamily?: string;
+  fontWeight?: number;
+  fontWeightBold?: number;
   className?: string;
   style?: React.CSSProperties;
 }
@@ -56,6 +58,8 @@ interface PaneLeafProps {
   theme?: Partial<Theme>;
   fontSize?: number;
   fontFamily?: string;
+  fontWeight?: number;
+  fontWeightBold?: number;
   onRef: (id: string, handle: TerminalHandle | null) => void;
   sharedContext: SharedWebGLContext | null;
 }
@@ -66,6 +70,8 @@ function PaneLeaf({
   theme,
   fontSize,
   fontFamily,
+  fontWeight,
+  fontWeightBold,
   onRef,
   sharedContext,
 }: PaneLeafProps) {
@@ -118,6 +124,8 @@ function PaneLeaf({
         theme={theme}
         fontSize={fontSize}
         fontFamily={fontFamily}
+        fontWeight={fontWeight}
+        fontWeightBold={fontWeightBold}
         onData={handleData}
         sharedContext={sharedContext ?? undefined}
         paneId={sharedContext ? id : undefined}
@@ -137,6 +145,8 @@ interface PaneNodeProps {
   theme?: Partial<Theme>;
   fontSize?: number;
   fontFamily?: string;
+  fontWeight?: number;
+  fontWeightBold?: number;
   onRef: (id: string, handle: TerminalHandle | null) => void;
   sharedContext: SharedWebGLContext | null;
 }
@@ -147,6 +157,8 @@ function PaneNode({
   theme,
   fontSize,
   fontFamily,
+  fontWeight,
+  fontWeightBold,
   onRef,
   sharedContext,
 }: PaneNodeProps) {
@@ -158,6 +170,8 @@ function PaneNode({
         theme={theme}
         fontSize={fontSize}
         fontFamily={fontFamily}
+        fontWeight={fontWeight}
+        fontWeightBold={fontWeightBold}
         onRef={onRef}
         sharedContext={sharedContext}
       />
@@ -202,6 +216,8 @@ function PaneNode({
               theme={theme}
               fontSize={fontSize}
               fontFamily={fontFamily}
+              fontWeight={fontWeight}
+              fontWeightBold={fontWeightBold}
               onRef={onRef}
               sharedContext={sharedContext}
             />
@@ -218,7 +234,17 @@ function PaneNode({
 
 export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
   function TerminalPane(props, ref) {
-    const { layout, onData, theme, fontSize, fontFamily, className, style } = props;
+    const {
+      layout,
+      onData,
+      theme,
+      fontSize,
+      fontFamily,
+      fontWeight,
+      fontWeightBold,
+      className,
+      style,
+    } = props;
     const containerRef = useRef<HTMLDivElement>(null);
     const terminalsRef = useRef<Map<string, TerminalHandle>>(new Map());
     const sharedContextRef = useRef<SharedWebGLContext | null>(null);
@@ -339,6 +365,8 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
           theme={theme}
           fontSize={fontSize}
           fontFamily={fontFamily}
+          fontWeight={fontWeight}
+          fontWeightBold={fontWeightBold}
           onRef={handleRef}
           sharedContext={sharedContext}
         />

--- a/packages/web/src/__tests__/renderer-rendering.test.ts
+++ b/packages/web/src/__tests__/renderer-rendering.test.ts
@@ -585,7 +585,7 @@ describe("Canvas2DRenderer — text attribute rendering", () => {
 
     const textOp = mockCtx.ops.find((o) => o.type === "fillText");
     expect(textOp).toBeDefined();
-    expect(textOp?.font).toContain("bold");
+    expect(textOp?.font).toContain("700");
     expect(textOp?.font).not.toContain("italic");
     renderer.dispose();
   });
@@ -599,7 +599,7 @@ describe("Canvas2DRenderer — text attribute rendering", () => {
     const textOp = mockCtx.ops.find((o) => o.type === "fillText");
     expect(textOp).toBeDefined();
     expect(textOp?.font).toContain("italic");
-    expect(textOp?.font).not.toContain("bold");
+    expect(textOp?.font).toContain("400");
     renderer.dispose();
   });
 
@@ -611,7 +611,7 @@ describe("Canvas2DRenderer — text attribute rendering", () => {
 
     const textOp = mockCtx.ops.find((o) => o.type === "fillText");
     expect(textOp).toBeDefined();
-    expect(textOp?.font).toContain("bold");
+    expect(textOp?.font).toContain("700");
     expect(textOp?.font).toContain("italic");
     renderer.dispose();
   });

--- a/packages/web/src/__tests__/web-terminal.test.ts
+++ b/packages/web/src/__tests__/web-terminal.test.ts
@@ -287,7 +287,7 @@ describe("WebTerminal", () => {
       const spy = vi.spyOn(Canvas2DRenderer.prototype, "setFont");
       const t = make(container);
       t.setFont(18, "Courier New");
-      expect(spy).toHaveBeenCalledWith(18, "Courier New");
+      expect(spy).toHaveBeenCalledWith(18, "Courier New", undefined, undefined);
       t.dispose();
     });
   });

--- a/packages/web/src/__tests__/webgl-renderer.test.ts
+++ b/packages/web/src/__tests__/webgl-renderer.test.ts
@@ -183,7 +183,7 @@ describe("packGlyphInstance", () => {
 
 describe("GlyphAtlas", () => {
   it("creates with specified initial size", () => {
-    const atlas = new GlyphAtlas(14, "monospace", 256);
+    const atlas = new GlyphAtlas(14, "monospace", 400, 700, 256);
     expect(atlas.width).toBe(256);
     expect(atlas.height).toBe(256);
   });

--- a/packages/web/src/render-bridge.ts
+++ b/packages/web/src/render-bridge.ts
@@ -34,6 +34,8 @@ export function canUseOffscreenCanvas(): boolean {
 export interface RenderBridgeOptions {
   fontSize: number;
   fontFamily: string;
+  fontWeight?: number;
+  fontWeightBold?: number;
   theme: Theme;
   devicePixelRatio?: number;
   /** Called when the worker reports FPS. */
@@ -79,6 +81,8 @@ export class RenderBridge {
       theme: this.options.theme,
       fontSize: this.options.fontSize,
       fontFamily: this.options.fontFamily,
+      fontWeight: this.options.fontWeight ?? 400,
+      fontWeightBold: this.options.fontWeightBold ?? 700,
       devicePixelRatio:
         this.options.devicePixelRatio ??
         (typeof devicePixelRatio !== "undefined" ? devicePixelRatio : 1),
@@ -158,13 +162,20 @@ export class RenderBridge {
   /**
    * Update the render worker's font settings.
    */
-  setFont(fontSize: number, fontFamily: string): void {
+  setFont(
+    fontSize: number,
+    fontFamily: string,
+    fontWeight?: number,
+    fontWeightBold?: number,
+  ): void {
     if (this.disposed || !this.worker) return;
 
     const msg: RenderWorkerFontMessage = {
       type: "font",
       fontSize,
       fontFamily,
+      fontWeight: fontWeight ?? 400,
+      fontWeightBold: fontWeightBold ?? 700,
     };
     this.worker.postMessage(msg);
   }

--- a/packages/web/src/render-worker.ts
+++ b/packages/web/src/render-worker.ts
@@ -44,6 +44,8 @@ export interface RenderWorkerInitMessage {
   theme: Theme;
   fontSize: number;
   fontFamily: string;
+  fontWeight: number;
+  fontWeightBold: number;
   devicePixelRatio: number;
 }
 
@@ -69,6 +71,8 @@ export interface RenderWorkerFontMessage {
   type: "font";
   fontSize: number;
   fontFamily: string;
+  fontWeight: number;
+  fontWeightBold: number;
 }
 
 export interface RenderWorkerDisposeMessage {
@@ -211,6 +215,8 @@ let rows = 0;
 let dpr = 1;
 let fontSize = 14;
 let fontFamily = "monospace";
+let fontWeight = 400;
+let fontWeightBold = 700;
 let theme: Theme = DEFAULT_THEME;
 let palette: string[] = [];
 let paletteFloat: ColorFloat4[] = [];
@@ -287,7 +293,7 @@ function measureCellSize(): void {
     return;
   }
 
-  ctx.font = `${fontSize}px ${fontFamily}`;
+  ctx.font = `${fontWeight} ${fontSize}px ${fontFamily}`;
   const metrics = ctx.measureText("M");
 
   cellWidth = Math.ceil(metrics.width);
@@ -922,6 +928,8 @@ function handleMessage(msg: RenderWorkerInboundMessage): void {
       theme = msg.theme;
       fontSize = msg.fontSize;
       fontFamily = msg.fontFamily;
+      fontWeight = msg.fontWeight;
+      fontWeightBold = msg.fontWeightBold;
       dpr = msg.devicePixelRatio;
 
       buildPaletteFloat();
@@ -929,7 +937,7 @@ function handleMessage(msg: RenderWorkerInboundMessage): void {
 
       grid = createGridFromSAB(msg.sharedBuffer, cols, rows);
 
-      atlas = new GlyphAtlas(Math.round(fontSize * dpr), fontFamily);
+      atlas = new GlyphAtlas(Math.round(fontSize * dpr), fontFamily, fontWeight, fontWeightBold);
 
       gl = canvas.getContext("webgl2", {
         alpha: false,
@@ -1018,12 +1026,14 @@ function handleMessage(msg: RenderWorkerInboundMessage): void {
     case "font": {
       fontSize = msg.fontSize;
       fontFamily = msg.fontFamily;
+      fontWeight = msg.fontWeight;
+      fontWeightBold = msg.fontWeightBold;
       measureCellSize();
 
       if (gl && atlas) {
         atlas.dispose(gl);
       }
-      atlas = new GlyphAtlas(Math.round(fontSize * dpr), fontFamily);
+      atlas = new GlyphAtlas(Math.round(fontSize * dpr), fontFamily, fontWeight, fontWeightBold);
 
       if (gl) {
         initGLResources();

--- a/packages/web/src/renderer.ts
+++ b/packages/web/src/renderer.ts
@@ -10,6 +10,10 @@ export interface RendererOptions {
   fontFamily: string;
   theme: Theme;
   devicePixelRatio?: number;
+  /** CSS font-weight for normal text (default: 400). */
+  fontWeight?: number;
+  /** CSS font-weight for bold text (default: 700). */
+  fontWeightBold?: number;
 }
 
 export interface HighlightRange {
@@ -111,6 +115,8 @@ export class Canvas2DRenderer implements IRenderer {
 
   private fontSize: number;
   private fontFamily: string;
+  private fontWeight: number;
+  private fontWeightBold: number;
   private theme: Theme;
   private dpr: number;
   private palette: string[];
@@ -128,6 +134,8 @@ export class Canvas2DRenderer implements IRenderer {
   constructor(options: RendererOptions) {
     this.fontSize = options.fontSize;
     this.fontFamily = options.fontFamily;
+    this.fontWeight = options.fontWeight ?? 400;
+    this.fontWeightBold = options.fontWeightBold ?? 700;
     this.theme = options.theme ?? DEFAULT_THEME;
     this.dpr =
       options.devicePixelRatio ?? (typeof devicePixelRatio !== "undefined" ? devicePixelRatio : 1);
@@ -288,9 +296,16 @@ export class Canvas2DRenderer implements IRenderer {
     }
   }
 
-  setFont(fontSize: number, fontFamily: string): void {
+  setFont(
+    fontSize: number,
+    fontFamily: string,
+    fontWeight?: number,
+    fontWeightBold?: number,
+  ): void {
     this.fontSize = fontSize;
     this.fontFamily = fontFamily;
+    if (fontWeight !== undefined) this.fontWeight = fontWeight;
+    if (fontWeightBold !== undefined) this.fontWeightBold = fontWeightBold;
     this.measureCellSize();
     if (this.grid) {
       this.syncCanvasSize();
@@ -410,7 +425,7 @@ export class Canvas2DRenderer implements IRenderer {
   private buildFontString(bold: boolean, italic: boolean): string {
     let font = "";
     if (italic) font += "italic ";
-    if (bold) font += "bold ";
+    font += `${bold ? this.fontWeightBold : this.fontWeight} `;
     font += `${this.fontSize}px ${this.fontFamily}`;
     return font;
   }

--- a/packages/web/src/shared-context.ts
+++ b/packages/web/src/shared-context.ts
@@ -241,6 +241,8 @@ export class SharedWebGLContext {
 
   private fontSize: number;
   private fontFamily: string;
+  private fontWeight: number;
+  private fontWeightBold: number;
   private dpr: number;
   private cellWidth = 0;
   private cellHeight = 0;
@@ -248,11 +250,15 @@ export class SharedWebGLContext {
   constructor(options?: {
     fontSize?: number;
     fontFamily?: string;
+    fontWeight?: number;
+    fontWeightBold?: number;
     theme?: Partial<Theme>;
     devicePixelRatio?: number;
   }) {
     this.fontSize = options?.fontSize ?? 14;
     this.fontFamily = options?.fontFamily ?? "'Menlo', 'DejaVu Sans Mono', 'Consolas', monospace";
+    this.fontWeight = options?.fontWeight ?? 400;
+    this.fontWeightBold = options?.fontWeightBold ?? 700;
     this.theme = { ...DEFAULT_THEME, ...options?.theme };
     this.dpr =
       options?.devicePixelRatio ?? (typeof devicePixelRatio !== "undefined" ? devicePixelRatio : 1);
@@ -260,7 +266,12 @@ export class SharedWebGLContext {
     this.buildPaletteFloat();
     this.measureCellSize();
 
-    this.atlas = new GlyphAtlas(Math.round(this.fontSize * this.dpr), this.fontFamily);
+    this.atlas = new GlyphAtlas(
+      Math.round(this.fontSize * this.dpr),
+      this.fontFamily,
+      this.fontWeight,
+      this.fontWeightBold,
+    );
 
     // Pre-allocate instance buffers for batched rendering (all terminals combined)
     const maxCells = 80 * 24 * 4; // start with 4 terminals worth
@@ -980,7 +991,7 @@ export class SharedWebGLContext {
       return;
     }
 
-    const font = `${this.fontSize}px ${this.fontFamily}`;
+    const font = `${this.fontWeight} ${this.fontSize}px ${this.fontFamily}`;
     measureCtx.font = font;
     const metrics = measureCtx.measureText("M");
 

--- a/packages/web/src/web-terminal.ts
+++ b/packages/web/src/web-terminal.ts
@@ -45,6 +45,10 @@ export interface WebTerminalOptions {
   rows?: number;
   fontSize?: number;
   fontFamily?: string;
+  /** CSS font-weight for normal text (default: 400). */
+  fontWeight?: number;
+  /** CSS font-weight for bold text (default: 700). */
+  fontWeightBold?: number;
   theme?: Partial<Theme>;
   scrollback?: number;
   devicePixelRatio?: number;
@@ -112,7 +116,12 @@ export class WebTerminal {
   private renderer: IRenderer & {
     startRenderLoop(): void;
     stopRenderLoop(): void;
-    setFont?(fontSize: number, fontFamily: string): void;
+    setFont?(
+      fontSize: number,
+      fontFamily: string,
+      fontWeight?: number,
+      fontWeightBold?: number,
+    ): void;
   };
   private inputHandler: InputHandler;
   private disposed = false;
@@ -196,11 +205,15 @@ export class WebTerminal {
 
     // Create renderer based on selected backend
     const rendererType = options?.renderer ?? "auto";
+    const fontWeight = options?.fontWeight;
+    const fontWeightBold = options?.fontWeightBold;
     const rendererOpts: RendererOptions = {
       fontSize,
       fontFamily,
       theme,
       devicePixelRatio: options?.devicePixelRatio,
+      fontWeight,
+      fontWeightBold,
     };
 
     if (options?.sharedContext && options?.paneId) {
@@ -662,12 +675,17 @@ export class WebTerminal {
     this.renderer.setTheme(merged);
   }
 
-  setFont(fontSize: number, fontFamily: string): void {
+  setFont(
+    fontSize: number,
+    fontFamily: string,
+    fontWeight?: number,
+    fontWeightBold?: number,
+  ): void {
     if (this.renderBridge) {
-      this.renderBridge.setFont(fontSize, fontFamily);
+      this.renderBridge.setFont(fontSize, fontFamily, fontWeight, fontWeightBold);
     }
     if (this.renderer.setFont) {
-      this.renderer.setFont(fontSize, fontFamily);
+      this.renderer.setFont(fontSize, fontFamily, fontWeight, fontWeightBold);
     }
     const { width, height } = this.renderer.getCellSize();
     this.inputHandler.updateCellSize(width, height);

--- a/packages/web/src/webgl-renderer.ts
+++ b/packages/web/src/webgl-renderer.ts
@@ -144,10 +144,20 @@ export class GlyphAtlas {
 
   private fontSize: number;
   private fontFamily: string;
+  private fontWeight: number;
+  private fontWeightBold: number;
 
-  constructor(fontSize: number, fontFamily: string, initialSize = 512) {
+  constructor(
+    fontSize: number,
+    fontFamily: string,
+    fontWeight = 400,
+    fontWeightBold = 700,
+    initialSize = 512,
+  ) {
     this.fontSize = fontSize;
     this.fontFamily = fontFamily;
+    this.fontWeight = fontWeight;
+    this.fontWeightBold = fontWeightBold;
     this.width = initialSize;
     this.height = initialSize;
 
@@ -269,7 +279,7 @@ export class GlyphAtlas {
   private buildFont(bold: boolean, italic: boolean): string {
     let font = "";
     if (italic) font += "italic ";
-    if (bold) font += "bold ";
+    font += `${bold ? this.fontWeightBold : this.fontWeight} `;
     font += `${this.fontSize}px ${this.fontFamily}`;
     return font;
   }
@@ -503,6 +513,8 @@ export class WebGLRenderer implements IRenderer {
 
   private fontSize: number;
   private fontFamily: string;
+  private fontWeight: number;
+  private fontWeightBold: number;
   private theme: Theme;
   private dpr: number;
   private palette: string[];
@@ -574,6 +586,8 @@ export class WebGLRenderer implements IRenderer {
   constructor(options: RendererOptions) {
     this.fontSize = options.fontSize;
     this.fontFamily = options.fontFamily;
+    this.fontWeight = options.fontWeight ?? 400;
+    this.fontWeightBold = options.fontWeightBold ?? 700;
     this.theme = options.theme ?? DEFAULT_THEME;
     this.dpr =
       options.devicePixelRatio ?? (typeof devicePixelRatio !== "undefined" ? devicePixelRatio : 1);
@@ -581,7 +595,12 @@ export class WebGLRenderer implements IRenderer {
     this.measureCellSize();
     this.buildPaletteFloat();
 
-    this.atlas = new GlyphAtlas(Math.round(this.fontSize * this.dpr), this.fontFamily);
+    this.atlas = new GlyphAtlas(
+      Math.round(this.fontSize * this.dpr),
+      this.fontFamily,
+      this.fontWeight,
+      this.fontWeightBold,
+    );
 
     // Pre-allocate instance buffers for a reasonable default size
     const maxCells = 80 * 24;
@@ -922,16 +941,28 @@ export class WebGLRenderer implements IRenderer {
     }
   }
 
-  setFont(fontSize: number, fontFamily: string): void {
+  setFont(
+    fontSize: number,
+    fontFamily: string,
+    fontWeight?: number,
+    fontWeightBold?: number,
+  ): void {
     this.fontSize = fontSize;
     this.fontFamily = fontFamily;
+    if (fontWeight !== undefined) this.fontWeight = fontWeight;
+    if (fontWeightBold !== undefined) this.fontWeightBold = fontWeightBold;
     this.measureCellSize();
 
-    // Recreate atlas with new font size
+    // Recreate atlas with new font size/weight
     if (this.gl) {
       this.atlas.dispose(this.gl);
     }
-    this.atlas = new GlyphAtlas(Math.round(this.fontSize * this.dpr), this.fontFamily);
+    this.atlas = new GlyphAtlas(
+      Math.round(this.fontSize * this.dpr),
+      this.fontFamily,
+      this.fontWeight,
+      this.fontWeightBold,
+    );
 
     if (this.grid) {
       this.syncCanvasSize();
@@ -1468,7 +1499,7 @@ export class WebGLRenderer implements IRenderer {
   private buildFontString(bold: boolean, italic: boolean): string {
     let font = "";
     if (italic) font += "italic ";
-    if (bold) font += "bold ";
+    font += `${bold ? this.fontWeightBold : this.fontWeight} `;
     font += `${this.fontSize}px ${this.fontFamily}`;
     return font;
   }


### PR DESCRIPTION
## Summary
- Adds `fontWeight` (default: 400) and `fontWeightBold` (default: 700) options to all renderer paths
- Threaded through: RendererOptions, Canvas2DRenderer, WebGLRenderer, GlyphAtlas, SharedWebGLContext, render worker, render bridge, React Terminal and TerminalPane components
- Allows downstream consumers to match terminal text weight to their UI

## Usage
```tsx
<Terminal fontWeight={300} fontWeightBold={600} />
```

## Test plan
- [x] 1505 unit tests pass
- [x] Typecheck clean
- [x] Tests updated for numeric weight in font strings (700 instead of "bold")

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)