### PR TITLE
fix(web): mouse wheel scroll in normal mode and calculateFit padding

### DIFF
--- a/packages/web/src/__tests__/fit.test.ts
+++ b/packages/web/src/__tests__/fit.test.ts
@@ -1,11 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { calculateFit } from "../fit.js";
 
 /**
- * Helper to create a mock HTMLElement with a given bounding rect.
+ * Helper to create a mock HTMLElement with a given bounding rect and padding.
+ * Installs a global getComputedStyle mock so calculateFit can read padding.
  */
-function mockContainer(width: number, height: number): HTMLElement {
-  return {
+function mockContainer(
+  width: number,
+  height: number,
+  padding: { top?: number; right?: number; bottom?: number; left?: number } = {},
+): HTMLElement {
+  const el = {
     getBoundingClientRect: () => ({
       width,
       height,
@@ -18,9 +23,24 @@ function mockContainer(width: number, height: number): HTMLElement {
       toJSON() {},
     }),
   } as unknown as HTMLElement;
+
+  // Install getComputedStyle on globalThis so calculateFit can use it
+  (globalThis as Record<string, unknown>).getComputedStyle = () =>
+    ({
+      paddingTop: `${padding.top ?? 0}px`,
+      paddingRight: `${padding.right ?? 0}px`,
+      paddingBottom: `${padding.bottom ?? 0}px`,
+      paddingLeft: `${padding.left ?? 0}px`,
+    }) as unknown as CSSStyleDeclaration;
+
+  return el;
 }
 
 describe("calculateFit", () => {
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).getComputedStyle;
+  });
+
   it("calculates columns and rows for a normal container", () => {
     const result = calculateFit(mockContainer(800, 600), 8, 16);
     expect(result.cols).toBe(100);
@@ -61,5 +81,35 @@ describe("calculateFit", () => {
     const result = calculateFit(mockContainer(805, 601), 8.5, 16.5);
     expect(result.cols).toBe(Math.max(2, Math.floor(805 / 8.5)));
     expect(result.rows).toBe(Math.max(1, Math.floor(601 / 16.5)));
+  });
+
+  it("subtracts uniform padding from container dimensions", () => {
+    // 350x283 container with 16px padding on all sides → content area 318x251
+    const result = calculateFit(
+      mockContainer(350, 283, { top: 16, right: 16, bottom: 16, left: 16 }),
+      9,
+      16,
+    );
+    // 318/9 = 35.3 → 35 cols, 251/16 = 15.6 → 15 rows
+    expect(result.cols).toBe(35);
+    expect(result.rows).toBe(15);
+  });
+
+  it("subtracts asymmetric padding correctly", () => {
+    // 800x600 with padding: 10px top, 20px right, 30px bottom, 40px left
+    // content: (800-20-40) x (600-10-30) = 740 x 560
+    const result = calculateFit(
+      mockContainer(800, 600, { top: 10, right: 20, bottom: 30, left: 40 }),
+      8,
+      16,
+    );
+    expect(result.cols).toBe(Math.floor(740 / 8));
+    expect(result.rows).toBe(Math.floor(560 / 16));
+  });
+
+  it("handles zero padding (no change from bounding rect)", () => {
+    const result = calculateFit(mockContainer(800, 600), 8, 16);
+    expect(result.cols).toBe(100);
+    expect(result.rows).toBe(37);
   });
 });

--- a/packages/web/src/__tests__/input-handler.test.ts
+++ b/packages/web/src/__tests__/input-handler.test.ts
@@ -59,76 +59,46 @@ describe("InputHandler", () => {
   });
 
   describe("mouse wheel scrolling in normal mode", () => {
-    it("calls onScroll with positive lines when scrolling down", () => {
+    function setupWheel() {
       const onData = vi.fn();
       const onScroll = vi.fn();
       const handler = new InputHandler({ onData, onScroll });
-
-      // Simulate attach with a cell height of 16px
       const container = document.createElement("div");
       container.style.width = "800px";
       container.style.height = "400px";
       document.body.appendChild(container);
       handler.attach(container, 8, 16);
 
-      // Dispatch a wheel event (deltaY > 0 = scroll down)
-      const wheelEvent = new WheelEvent("wheel", {
-        deltaY: 48,
-        bubbles: true,
-        cancelable: true,
-      });
-      container.dispatchEvent(wheelEvent);
+      const dispatch = (deltaY: number) =>
+        container.dispatchEvent(
+          new WheelEvent("wheel", { deltaY, bubbles: true, cancelable: true }),
+        );
+      const teardown = () => {
+        handler.dispose();
+        document.body.removeChild(container);
+      };
+      return { onScroll, dispatch, teardown };
+    }
 
+    it("calls onScroll with positive lines when scrolling down", () => {
+      const { onScroll, dispatch, teardown } = setupWheel();
+      dispatch(48);
       expect(onScroll).toHaveBeenCalledWith(3); // 48 / 16 = 3 lines
-      handler.dispose();
-      document.body.removeChild(container);
+      teardown();
     });
 
     it("calls onScroll with negative lines when scrolling up", () => {
-      const onData = vi.fn();
-      const onScroll = vi.fn();
-      const handler = new InputHandler({ onData, onScroll });
-
-      const container = document.createElement("div");
-      container.style.width = "800px";
-      container.style.height = "400px";
-      document.body.appendChild(container);
-      handler.attach(container, 8, 16);
-
-      const wheelEvent = new WheelEvent("wheel", {
-        deltaY: -32,
-        bubbles: true,
-        cancelable: true,
-      });
-      container.dispatchEvent(wheelEvent);
-
+      const { onScroll, dispatch, teardown } = setupWheel();
+      dispatch(-32);
       expect(onScroll).toHaveBeenCalledWith(-2); // -32 / 16 = -2 lines
-      handler.dispose();
-      document.body.removeChild(container);
+      teardown();
     });
 
     it("does not call onScroll when deltaY rounds to zero lines", () => {
-      const onData = vi.fn();
-      const onScroll = vi.fn();
-      const handler = new InputHandler({ onData, onScroll });
-
-      const container = document.createElement("div");
-      container.style.width = "800px";
-      container.style.height = "400px";
-      document.body.appendChild(container);
-      handler.attach(container, 8, 16);
-
-      // Small deltaY that rounds to 0 lines
-      const wheelEvent = new WheelEvent("wheel", {
-        deltaY: 2,
-        bubbles: true,
-        cancelable: true,
-      });
-      container.dispatchEvent(wheelEvent);
-
+      const { onScroll, dispatch, teardown } = setupWheel();
+      dispatch(2); // too small to round to 1 line
       expect(onScroll).not.toHaveBeenCalled();
-      handler.dispose();
-      document.body.removeChild(container);
+      teardown();
     });
   });
 

--- a/packages/web/src/__tests__/input-handler.test.ts
+++ b/packages/web/src/__tests__/input-handler.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import { CellGrid } from "@next_term/core";
 import { describe, expect, it, vi } from "vitest";
 import { InputHandler } from "../input-handler.js";
@@ -53,6 +55,80 @@ describe("InputHandler", () => {
         shiftKey: false,
       } as KeyboardEvent);
       expect(seq).toBeNull();
+    });
+  });
+
+  describe("mouse wheel scrolling in normal mode", () => {
+    it("calls onScroll with positive lines when scrolling down", () => {
+      const onData = vi.fn();
+      const onScroll = vi.fn();
+      const handler = new InputHandler({ onData, onScroll });
+
+      // Simulate attach with a cell height of 16px
+      const container = document.createElement("div");
+      container.style.width = "800px";
+      container.style.height = "400px";
+      document.body.appendChild(container);
+      handler.attach(container, 8, 16);
+
+      // Dispatch a wheel event (deltaY > 0 = scroll down)
+      const wheelEvent = new WheelEvent("wheel", {
+        deltaY: 48,
+        bubbles: true,
+        cancelable: true,
+      });
+      container.dispatchEvent(wheelEvent);
+
+      expect(onScroll).toHaveBeenCalledWith(3); // 48 / 16 = 3 lines
+      handler.dispose();
+      document.body.removeChild(container);
+    });
+
+    it("calls onScroll with negative lines when scrolling up", () => {
+      const onData = vi.fn();
+      const onScroll = vi.fn();
+      const handler = new InputHandler({ onData, onScroll });
+
+      const container = document.createElement("div");
+      container.style.width = "800px";
+      container.style.height = "400px";
+      document.body.appendChild(container);
+      handler.attach(container, 8, 16);
+
+      const wheelEvent = new WheelEvent("wheel", {
+        deltaY: -32,
+        bubbles: true,
+        cancelable: true,
+      });
+      container.dispatchEvent(wheelEvent);
+
+      expect(onScroll).toHaveBeenCalledWith(-2); // -32 / 16 = -2 lines
+      handler.dispose();
+      document.body.removeChild(container);
+    });
+
+    it("does not call onScroll when deltaY rounds to zero lines", () => {
+      const onData = vi.fn();
+      const onScroll = vi.fn();
+      const handler = new InputHandler({ onData, onScroll });
+
+      const container = document.createElement("div");
+      container.style.width = "800px";
+      container.style.height = "400px";
+      document.body.appendChild(container);
+      handler.attach(container, 8, 16);
+
+      // Small deltaY that rounds to 0 lines
+      const wheelEvent = new WheelEvent("wheel", {
+        deltaY: 2,
+        bubbles: true,
+        cancelable: true,
+      });
+      container.dispatchEvent(wheelEvent);
+
+      expect(onScroll).not.toHaveBeenCalled();
+      handler.dispose();
+      document.body.removeChild(container);
     });
   });
 

--- a/packages/web/src/fit.ts
+++ b/packages/web/src/fit.ts
@@ -12,7 +12,6 @@ export function calculateFit(
   let width = rect.width;
   let height = rect.height;
 
-  // Subtract CSS padding so the canvas fits inside the content box.
   if (typeof getComputedStyle === "function") {
     const style = getComputedStyle(container);
     width -= (parseFloat(style.paddingLeft) || 0) + (parseFloat(style.paddingRight) || 0);

--- a/packages/web/src/fit.ts
+++ b/packages/web/src/fit.ts
@@ -1,12 +1,23 @@
 /**
  * Calculate how many terminal columns/rows fit in a container element.
+ * Subtracts CSS padding so the canvas fits inside the content box.
  */
 export function calculateFit(
   container: HTMLElement,
   cellWidth: number,
   cellHeight: number,
 ): { cols: number; rows: number } {
-  const { width, height } = container.getBoundingClientRect();
+  const rect = container.getBoundingClientRect();
+
+  let width = rect.width;
+  let height = rect.height;
+
+  // Subtract CSS padding so the canvas fits inside the content box.
+  if (typeof getComputedStyle === "function") {
+    const style = getComputedStyle(container);
+    width -= (parseFloat(style.paddingLeft) || 0) + (parseFloat(style.paddingRight) || 0);
+    height -= (parseFloat(style.paddingTop) || 0) + (parseFloat(style.paddingBottom) || 0);
+  }
 
   const cols = Math.max(2, Math.floor(width / cellWidth));
   const rows = Math.max(1, Math.floor(height / cellHeight));

--- a/packages/web/src/input-handler.ts
+++ b/packages/web/src/input-handler.ts
@@ -1073,6 +1073,13 @@ export class InputHandler {
       if (!pos) return;
       const button = e.deltaY < 0 ? 64 : 65;
       this.onData(toBytes(this.encodeMouseEvent(button, pos.col, pos.row)));
+    } else if (this.onScroll && this.cellHeight > 0) {
+      // Normal mode — scroll the viewport through scrollback history
+      e.preventDefault();
+      const lines = Math.round(e.deltaY / this.cellHeight);
+      if (lines !== 0) {
+        this.onScroll(lines);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Fix mouse wheel scrolling when no mouse protocol is active (the common case). `handleWheel()` was silently dropping wheel events in normal mode. Now converts deltaY to line units and calls `onScroll()`. Fixes #122.
- Fix `calculateFit()` using `getBoundingClientRect()` which includes CSS padding, causing canvas overflow in padded containers. Now subtracts padding via `getComputedStyle()`. Fixes #123.

## Test plan

- [x] 3 new wheel scroll tests: positive delta, negative delta, zero-line guard
- [x] 3 new padding tests: uniform 16px, asymmetric padding, zero padding baseline
- [x] All 1586 tests pass
- [x] Lint clean
- [x] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)