### PR TITLE
fix: use .js extensions in Worker URL references (#155)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ react-term — Modern terminal emulator for React/React Native
 - Dirty tracking: Int32Array with Atomics (NOT Uint8Array — Atomics requires >=32-bit)
 - Default fg=7 (white), default bg=0 (black) — always set in clear/erase operations
 - SAB feature detection: `typeof SharedArrayBuffer !== 'undefined' && crossOriginIsolated`
-- Worker instantiation: `new Worker(new URL('./file.ts', import.meta.url), { type: 'module' })`
+- Worker instantiation: `new Worker(new URL('./file.js', import.meta.url), { type: 'module' })`
 - Demo Vite config has COOP/COEP headers for SAB support
 
 ## Testing

--- a/packages/web/src/render-bridge.ts
+++ b/packages/web/src/render-bridge.ts
@@ -66,7 +66,7 @@ export class RenderBridge {
   start(sharedBuffer: SharedArrayBuffer, cols: number, rows: number): void {
     if (this.disposed) return;
 
-    this.worker = new Worker(new URL("./render-worker.ts", import.meta.url), { type: "module" });
+    this.worker = new Worker(new URL("./render-worker.js", import.meta.url), { type: "module" });
 
     this.worker.addEventListener("message", this.handleWorkerMessage);
     this.worker.addEventListener("error", this.handleWorkerError);

--- a/packages/web/src/worker-bridge.ts
+++ b/packages/web/src/worker-bridge.ts
@@ -68,7 +68,7 @@ export class WorkerBridge {
   start(cols: number, rows: number, scrollback: number): void {
     if (this.disposed) return;
 
-    this.worker = new Worker(new URL("./parser-worker.ts", import.meta.url), { type: "module" });
+    this.worker = new Worker(new URL("./parser-worker.js", import.meta.url), { type: "module" });
 
     this.worker.addEventListener("message", this.handleWorkerMessage);
     this.worker.addEventListener("error", this.handleWorkerError);


### PR DESCRIPTION
## Summary

The dist files referenced `.ts` worker files (`parser-worker.ts`, `render-worker.ts`) in `new Worker(new URL(...))` calls. This works in dev mode (Vite resolves `.ts` natively) but **breaks production builds** — bundlers can't resolve `.ts` from `node_modules`.

Changed to `.js` extensions which `tsc` passes through to dist verbatim, matching the compiled output filenames.

## Changes

- `packages/web/src/worker-bridge.ts`: `./parser-worker.ts` → `./parser-worker.js`
- `packages/web/src/render-bridge.ts`: `./render-worker.ts` → `./render-worker.js`
- `CLAUDE.md`: Updated convention to match

## Verification

Built `packages/web` and confirmed dist output:
```
dist/worker-bridge.js: new Worker(new URL("./parser-worker.js", import.meta.url))
dist/render-bridge.js: new Worker(new URL("./render-worker.js", import.meta.url))
```

## Test plan

- [x] 1702 tests pass
- [x] Type-check clean
- [x] `pnpm run build` produces correct dist output

Closes #155