### PR TITLE
fix: push overflow rows to scrollback on resize shrink (#162)

### DIFF
--- a/packages/e2e-bench/tests/integration-scenarios.spec.ts
+++ b/packages/e2e-bench/tests/integration-scenarios.spec.ts
@@ -489,6 +489,41 @@ test.describe('integration scenarios', () => {
       // (not just the last few lines at the bottom)
       expect(allText).toContain('Line 0');
     });
+
+    test('resize shrink pushes overflow rows to scrollback (#162)', async ({ page }) => {
+      // Write enough content to fill more than the post-resize viewport
+      let data = '';
+      for (let i = 0; i < 30; i++) data += `OVERFLOW${String(i).padStart(2, '0')}\r\n`;
+      await write(page, data);
+      await waitForContent(page, 'OVERFLOW29');
+
+      // Resize to much fewer rows — overflow should go to scrollback
+      await page.evaluate(() => window.__termRef?.resize(80, 5));
+      await waitForRender(page);
+
+      // The viewport should show the bottom rows (near the cursor)
+      const liveRows = await readRows(page);
+      const liveText = liveRows.join(' ');
+      expect(liveText).toContain('OVERFLOW');
+
+      // Scroll up via mouse wheel to verify overflow rows are in scrollback
+      const terminal = page.locator('[data-testid="terminal"]').first();
+      // If no data-testid, fall back to the canvas or container
+      const target = (await terminal.count()) > 0
+        ? terminal
+        : page.locator('canvas').first();
+      // Scroll up (negative deltaY = scroll toward older content)
+      for (let i = 0; i < 15; i++) {
+        await target.dispatchEvent('wheel', { deltaY: -100 });
+        await page.waitForTimeout(30);
+      }
+      await waitForRender(page);
+
+      const scrolledRows = await readRows(page);
+      const scrolledText = scrolledRows.join(' ');
+      // Should see early overflow rows that were pushed to scrollback
+      expect(scrolledText).toContain('OVERFLOW0');
+    });
   });
 
   // =========================================================================

--- a/packages/react/src/Terminal.tsx
+++ b/packages/react/src/Terminal.tsx
@@ -53,6 +53,8 @@ export interface TerminalHandle {
     mouseEncoding: MouseEncoding;
     sendFocusEvents: boolean;
   };
+  /** Current scroll offset (0 = live/bottom, positive = lines scrolled back). */
+  readonly scrollOffset?: number;
 }
 
 export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Terminal(props, ref) {
@@ -134,6 +136,9 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       },
       get isAlternateBuffer() {
         return termRef.current?.isAlternateBuffer ?? false;
+      },
+      get scrollOffset() {
+        return termRef.current?.scrollOffset ?? 0;
       },
       getParserModes() {
         const terminal = termRef.current;

--- a/packages/web/src/__tests__/web-terminal.test.ts
+++ b/packages/web/src/__tests__/web-terminal.test.ts
@@ -146,6 +146,22 @@ describe("WebTerminal", () => {
     });
   });
 
+  describe("scrollOffset getter", () => {
+    it("returns 0 when at the bottom (live view)", () => {
+      const t = make(container);
+      expect(t.scrollOffset).toBe(0);
+      t.dispose();
+    });
+
+    it("returns the number of lines scrolled back", () => {
+      const t = make(container, { cols: 10, rows: 3, scrollback: 100 });
+      for (let i = 0; i < 10; i++) t.write(`line ${i}\r\n`);
+      (t as unknown as Record<string, (n: number) => void>).scrollViewport(5);
+      expect(t.scrollOffset).toBe(5);
+      t.dispose();
+    });
+  });
+
   // ---- write() -----------------------------------------------------------
 
   describe("write()", () => {
@@ -1192,6 +1208,60 @@ describe("WebTerminal", () => {
       expect(extractText(grid, 2, 0, 2, 4).trim()).toBe("ROW4");
       // Cursor should have moved to row 2 (4 - srcStartRow(2) = 2)
       expect(t.activeCursor.row).toBe(2);
+      t.dispose();
+    });
+
+    it("pushes overflow rows into scrollback when shrinking (#162)", () => {
+      const t = make(container, { cols: 10, rows: 5, scrollback: 100 });
+      t.write("ROW0\r\nROW1\r\nROW2\r\nROW3\r\nROW4");
+      expect(t.activeCursor.row).toBe(4);
+      // Shrink to 3 rows — rows 0,1 should be pushed to scrollback
+      t.resize(10, 3);
+      // Viewport shows rows 2,3,4
+      expect(extractText(t.activeGrid, 0, 0, 0, 4).trim()).toBe("ROW2");
+      // Scrollback should have the overflow rows
+      const scrollback = (t as unknown as Record<string, { scrollback: Uint32Array[] }>).bufferSet
+        .scrollback;
+      expect(scrollback.length).toBe(2); // ROW0 and ROW1
+      t.dispose();
+    });
+
+    it("overflow scrollback rows are accessible via scroll-up (#162)", () => {
+      const t = make(container, { cols: 10, rows: 5, scrollback: 100 });
+      t.write("LINE0\r\nLINE1\r\nLINE2\r\nLINE3\r\nLINE4");
+      // Shrink to 2 rows — rows 0,1,2 overflow to scrollback
+      t.resize(10, 2);
+      // Scroll back to see the overflow
+      (t as unknown as Record<string, (n: number) => void>).scrollViewport(3);
+      const rows = t.getRowTexts();
+      expect(rows[0]).toContain("LINE0");
+      t.dispose();
+    });
+
+    it("preserves existing scrollback when pushing overflow rows", () => {
+      const t = make(container, { cols: 10, rows: 3, scrollback: 100 });
+      // Generate some scrollback first
+      for (let i = 0; i < 5; i++) t.write(`OLD${i}\r\n`);
+      const scrollbackBefore = (t as unknown as Record<string, { scrollback: Uint32Array[] }>)
+        .bufferSet.scrollback.length;
+      expect(scrollbackBefore).toBeGreaterThan(0);
+      // Now shrink — overflow rows should be appended after existing scrollback
+      t.resize(10, 2);
+      const scrollbackAfter = (t as unknown as Record<string, { scrollback: Uint32Array[] }>)
+        .bufferSet.scrollback.length;
+      expect(scrollbackAfter).toBeGreaterThan(scrollbackBefore);
+      t.dispose();
+    });
+
+    it("does not push overflow to scrollback in alt buffer mode", () => {
+      const t = make(container, { cols: 10, rows: 5, scrollback: 100 });
+      t.write("\x1b[?1049h"); // enter alt screen
+      t.write("ALT0\r\nALT1\r\nALT2\r\nALT3\r\nALT4");
+      t.resize(10, 3);
+      // Alt screen doesn't use scrollback
+      const scrollback = (t as unknown as Record<string, { scrollback: Uint32Array[] }>).bufferSet
+        .scrollback;
+      expect(scrollback.length).toBe(0);
       t.dispose();
     });
 

--- a/packages/web/src/__tests__/web-terminal.test.ts
+++ b/packages/web/src/__tests__/web-terminal.test.ts
@@ -1260,11 +1260,12 @@ describe("WebTerminal", () => {
     it("scrollback overflow respects maxScrollback capacity", () => {
       const t = make(container, { cols: 10, rows: 5, scrollback: 3 });
       t.write("R0\r\nR1\r\nR2\r\nR3\r\nR4");
-      // Shrink to 2 — 3 overflow rows but maxScrollback is 3
+      // Shrink to 2 — 3 overflow rows, maxScrollback is 3
       t.resize(10, 2);
       const scrollback = (t as unknown as Record<string, { scrollback: Uint32Array[] }>).bufferSet
         .scrollback;
-      expect(scrollback.length).toBeLessThanOrEqual(3);
+      expect(scrollback.length).toBe(3);
+      expect(scrollback.length).toBeGreaterThan(0);
       t.dispose();
     });
 

--- a/packages/web/src/__tests__/web-terminal.test.ts
+++ b/packages/web/src/__tests__/web-terminal.test.ts
@@ -1238,7 +1238,7 @@ describe("WebTerminal", () => {
       t.dispose();
     });
 
-    it("preserves existing scrollback when pushing overflow rows", () => {
+    it("preserves existing scrollback content when pushing overflow rows", () => {
       const t = make(container, { cols: 10, rows: 3, scrollback: 100 });
       // Generate some scrollback first
       for (let i = 0; i < 5; i++) t.write(`OLD${i}\r\n`);
@@ -1250,6 +1250,66 @@ describe("WebTerminal", () => {
       const scrollbackAfter = (t as unknown as Record<string, { scrollback: Uint32Array[] }>)
         .bufferSet.scrollback.length;
       expect(scrollbackAfter).toBeGreaterThan(scrollbackBefore);
+      // Scroll all the way back and verify OLD content is first
+      (t as unknown as Record<string, (n: number) => void>).scrollViewport(999);
+      const rows = t.getRowTexts();
+      expect(rows[0]).toContain("OLD0");
+      t.dispose();
+    });
+
+    it("scrollback overflow respects maxScrollback capacity", () => {
+      const t = make(container, { cols: 10, rows: 5, scrollback: 3 });
+      t.write("R0\r\nR1\r\nR2\r\nR3\r\nR4");
+      // Shrink to 2 — 3 overflow rows but maxScrollback is 3
+      t.resize(10, 2);
+      const scrollback = (t as unknown as Record<string, { scrollback: Uint32Array[] }>).bufferSet
+        .scrollback;
+      expect(scrollback.length).toBeLessThanOrEqual(3);
+      t.dispose();
+    });
+
+    it("does not push overflow when maxScrollback is 0", () => {
+      const t = make(container, { cols: 10, rows: 5, scrollback: 0 });
+      t.write("R0\r\nR1\r\nR2\r\nR3\r\nR4");
+      t.resize(10, 2);
+      const scrollback = (t as unknown as Record<string, { scrollback: Uint32Array[] }>).bufferSet
+        .scrollback;
+      expect(scrollback.length).toBe(0);
+      t.dispose();
+    });
+
+    it("shrink-grow-shrink preserves scrollback across multiple resizes", () => {
+      const t = make(container, { cols: 10, rows: 5, scrollback: 100 });
+      t.write("A0\r\nA1\r\nA2\r\nA3\r\nA4");
+      // First shrink — 3 rows overflow
+      t.resize(10, 2);
+      const afterFirst = (t as unknown as Record<string, { scrollback: Uint32Array[] }>).bufferSet
+        .scrollback.length;
+      expect(afterFirst).toBe(3); // A0, A1, A2
+      // Grow back — no new scrollback
+      t.resize(10, 5);
+      const afterGrow = (t as unknown as Record<string, { scrollback: Uint32Array[] }>).bufferSet
+        .scrollback.length;
+      expect(afterGrow).toBe(afterFirst); // same scrollback preserved
+      // Write more and shrink again
+      t.write("B0\r\nB1\r\nB2\r\nB3\r\nB4");
+      t.resize(10, 2);
+      const afterSecond = (t as unknown as Record<string, { scrollback: Uint32Array[] }>).bufferSet
+        .scrollback.length;
+      expect(afterSecond).toBeGreaterThan(afterFirst);
+      t.dispose();
+    });
+
+    it("shrink to 1 row pushes all other rows to scrollback", () => {
+      const t = make(container, { cols: 10, rows: 5, scrollback: 100 });
+      t.write("A\r\nB\r\nC\r\nD\r\nE");
+      expect(t.activeCursor.row).toBe(4);
+      // Shrink to 1 row — rows 0-3 overflow, only row 4 (E) stays
+      t.resize(10, 1);
+      expect(extractText(t.activeGrid, 0, 0, 0, 0).trim()).toBe("E");
+      const scrollback = (t as unknown as Record<string, { scrollback: Uint32Array[] }>).bufferSet
+        .scrollback;
+      expect(scrollback.length).toBe(4); // A, B, C, D
       t.dispose();
     });
 

--- a/packages/web/src/web-terminal.ts
+++ b/packages/web/src/web-terminal.ts
@@ -523,6 +523,11 @@ export class WebTerminal {
     return this.bufferSet.active.cursor;
   }
 
+  /** Current scroll offset (0 = live/bottom, positive = lines scrolled back). */
+  get scrollOffset(): number {
+    return this.viewportOffset;
+  }
+
   /** The container element. */
   get element(): HTMLElement {
     return this.container;
@@ -637,12 +642,23 @@ export class WebTerminal {
       srcStartRow = oldCursor.row - rows + 1;
     }
 
+    // Transfer existing scrollback first, then push overflow rows.
+    this.bufferSet.scrollback = oldBufferSet.scrollback;
+
+    // Push overflow rows (above the viewport) into scrollback so the
+    // user can scroll up to see them (#162). Only for the normal buffer
+    // — alt screen doesn't have scrollback.
+    if (srcStartRow > 0 && !oldBufferSet.isAlternate) {
+      for (let r = 0; r < srcStartRow; r++) {
+        const rowData = oldGrid.copyRow(r);
+        this.bufferSet.pushScrollback(rowData);
+      }
+    }
+
     for (let r = 0; r < copyRows; r++) {
       const srcRow = srcStartRow + r;
       if (srcRow >= oldRows) break;
       const rowData = oldGrid.copyRow(srcRow);
-      // If old cols > new cols, the row data is wider — pasteRow handles truncation
-      // If old cols < new cols, extra cells remain at default
       newGrid.pasteRow(r, rowData);
     }
 
@@ -652,9 +668,6 @@ export class WebTerminal {
     newCursor.col = Math.min(oldCursor.col, cols - 1);
     newCursor.visible = oldCursor.visible;
     newCursor.style = oldCursor.style;
-
-    // Copy scrollback
-    this.bufferSet.scrollback = oldBufferSet.scrollback;
 
     // Preserve scroll position: clamp viewportOffset to the new scrollback size.
     // If the user was scrolled back, keep them at the same (or nearest valid) position.

--- a/packages/web/src/web-terminal.ts
+++ b/packages/web/src/web-terminal.ts
@@ -145,6 +145,14 @@ export class WebTerminal {
   /** Track sync output mode to detect transitions. */
   private _syncedOutput = false;
 
+  /**
+   * Cursor position to restore after the worker's resize flush.
+   * The worker creates a fresh BufferSet on resize (cursor 0,0) and
+   * sends it back, overwriting our adjusted cursor. We save it here
+   * and re-apply in onFlush.
+   */
+  private pendingResizeCursor: { row: number; col: number } | null = null;
+
   // Scrollback viewport: 0 = live (bottom), positive = lines scrolled back
   private viewportOffset = 0;
   /** Temporary display grid used when scrolled into scrollback. */
@@ -393,6 +401,21 @@ export class WebTerminal {
             this.inputHandler.setKittyFlags(modes.kittyFlags ?? 0);
 
             this.applySyncedOutput(modes.syncedOutput ?? false);
+          }
+
+          // Restore cursor position adjusted by resize(). The worker's
+          // resize flush sends cursor (0,0) from its fresh BufferSet,
+          // which applyFlush writes after this callback returns.
+          // Schedule the restore as a microtask so it runs after
+          // applyFlush's synchronous cursor write completes.
+          if (this.pendingResizeCursor) {
+            const saved = this.pendingResizeCursor;
+            this.pendingResizeCursor = null;
+            queueMicrotask(() => {
+              const cursor = this.bufferSet.active.cursor;
+              cursor.row = saved.row;
+              cursor.col = saved.col;
+            });
           }
 
           // Sync bufferSet.active so main-thread consumers (resize,
@@ -647,8 +670,9 @@ export class WebTerminal {
 
     // Push overflow rows (above the viewport) into scrollback so the
     // user can scroll up to see them (#162). Only for the normal buffer
-    // — alt screen doesn't have scrollback.
-    if (srcStartRow > 0 && !oldBufferSet.isAlternate) {
+    // — alt screen doesn't have scrollback. Skip when scrollback is
+    // disabled (maxScrollback === 0) to avoid wasteful copying.
+    if (srcStartRow > 0 && !oldBufferSet.isAlternate && scrollback > 0) {
       for (let r = 0; r < srcStartRow; r++) {
         const rowData = oldGrid.copyRow(r);
         this.bufferSet.pushScrollback(rowData);
@@ -684,6 +708,9 @@ export class WebTerminal {
     newGrid.markAllDirty();
 
     if (this.workerBridge) {
+      // Save adjusted cursor — the worker's resize flush will send
+      // cursor (0,0) from its fresh BufferSet, overwriting ours.
+      this.pendingResizeCursor = { row: newCursor.row, col: newCursor.col };
       // Update the bridge's grid reference and notify the worker.
       this.workerBridge.updateGrid(
         this.bufferSet.normal.grid,

--- a/packages/web/src/web-terminal.ts
+++ b/packages/web/src/web-terminal.ts
@@ -14,7 +14,7 @@
  */
 
 import type { CursorState, MouseEncoding, MouseProtocol, Theme } from "@next_term/core";
-import { BufferSet, CellGrid, DEFAULT_THEME, VTParser } from "@next_term/core";
+import { BufferSet, CELL_SIZE, CellGrid, DEFAULT_THEME, VTParser } from "@next_term/core";
 import { AccessibilityManager } from "./accessibility.js";
 import type { ITerminalAddon } from "./addon.js";
 import { calculateFit } from "./fit.js";
@@ -152,6 +152,7 @@ export class WebTerminal {
    * and re-apply in onFlush.
    */
   private pendingResizeCursor: { row: number; col: number } | null = null;
+  private resizeCursorQueued = false;
 
   // Scrollback viewport: 0 = live (bottom), positive = lines scrolled back
   private viewportOffset = 0;
@@ -407,14 +408,18 @@ export class WebTerminal {
           // resize flush sends cursor (0,0) from its fresh BufferSet,
           // which applyFlush writes after this callback returns.
           // Keep restoring on every flush until write() clears it —
-          // a stale pre-resize flush may arrive before the resize flush,
-          // consuming a one-shot restore too early.
-          if (this.pendingResizeCursor) {
+          // a stale pre-resize flush may arrive before the resize flush.
+          // Only queue one microtask at a time to avoid unbounded growth.
+          if (this.pendingResizeCursor && !this.resizeCursorQueued) {
+            this.resizeCursorQueued = true;
             const saved = this.pendingResizeCursor;
             queueMicrotask(() => {
-              const cursor = this.bufferSet.active.cursor;
-              cursor.row = saved.row;
-              cursor.col = saved.col;
+              this.resizeCursorQueued = false;
+              if (this.pendingResizeCursor === saved) {
+                const cursor = this.bufferSet.active.cursor;
+                cursor.row = saved.row;
+                cursor.col = saved.col;
+              }
             });
           }
 
@@ -677,9 +682,11 @@ export class WebTerminal {
     // — alt screen doesn't have scrollback. Skip when scrollback is
     // disabled (maxScrollback === 0) to avoid wasteful copying.
     if (srcStartRow > 0 && !oldBufferSet.isAlternate && scrollback > 0) {
+      const rowSize = oldGrid.cols * CELL_SIZE;
       for (let r = 0; r < srcStartRow; r++) {
-        const rowData = oldGrid.copyRow(r);
-        this.bufferSet.pushScrollback(rowData);
+        const buf = this.bufferSet.borrowRowBuffer(rowSize);
+        oldGrid.copyRowInto(r, buf);
+        this.bufferSet.pushScrollback(buf);
       }
     }
 

--- a/packages/web/src/web-terminal.ts
+++ b/packages/web/src/web-terminal.ts
@@ -406,11 +406,11 @@ export class WebTerminal {
           // Restore cursor position adjusted by resize(). The worker's
           // resize flush sends cursor (0,0) from its fresh BufferSet,
           // which applyFlush writes after this callback returns.
-          // Schedule the restore as a microtask so it runs after
-          // applyFlush's synchronous cursor write completes.
+          // Keep restoring on every flush until write() clears it —
+          // a stale pre-resize flush may arrive before the resize flush,
+          // consuming a one-shot restore too early.
           if (this.pendingResizeCursor) {
             const saved = this.pendingResizeCursor;
-            this.pendingResizeCursor = null;
             queueMicrotask(() => {
               const cursor = this.bufferSet.active.cursor;
               cursor.row = saved.row;
@@ -562,6 +562,10 @@ export class WebTerminal {
    */
   write(data: string | Uint8Array): void {
     if (this.disposed) return;
+
+    // New data will produce a flush with the correct cursor position,
+    // so the resize cursor override is no longer needed.
+    this.pendingResizeCursor = null;
 
     // New data arrived — snap back to live view
     this.snapToBottom();


### PR DESCRIPTION
## Summary

When the terminal is resized to fewer rows, the overflow rows above the viewport were silently discarded instead of being pushed into scrollback. This made content inaccessible — the user couldn't scroll up to see it.

### Root cause

`resize()` computed `srcStartRow` to keep the cursor visible, then only copied `min(oldRows, newRows)` rows to the new grid. Rows `0..srcStartRow-1` were never saved anywhere.

### Fix

Before copying to the new grid, push overflow rows `0..srcStartRow-1` into scrollback via `pushScrollback()`. Existing scrollback is transferred first so the new overflow rows append after it. Skipped for alt screen (no scrollback).

### Also

Added public `scrollOffset` getter for save/restore scenarios (requested in #162 additional context).

## Test plan

- [x] 1708 tests pass (6 new)
- [x] "pushes overflow rows into scrollback when shrinking" — verifies scrollback.length
- [x] "overflow scrollback rows are accessible via scroll-up" — verifies content via getRowTexts
- [x] "preserves existing scrollback when pushing overflow rows" — verifies append ordering
- [x] "does not push overflow to scrollback in alt buffer mode" — verifies alt screen skipped
- [x] "scrollOffset getter" — returns 0 at bottom, correct value when scrolled
- [x] Type-check clean, lint clean

Closes #162