### PR TITLE
perf: pre-warm ASCII glyphs in atlas (#168 Phase 2)

### DIFF
--- a/packages/web/src/__tests__/webgl-renderer.test.ts
+++ b/packages/web/src/__tests__/webgl-renderer.test.ts
@@ -306,6 +306,27 @@ describe("GlyphAtlas", () => {
       expect(atlas.cache.size).toBe(18); // 33-50 = 18 glyphs
     }
   });
+
+  it("prewarmASCII populates cache with 188 glyphs (94 normal + 94 bold)", () => {
+    const atlas = new GlyphAtlas(14, "monospace");
+    atlas.prewarmASCII();
+    // If OffscreenCanvas is available, ASCII 33-126 × 2 weights are cached
+    const g = atlas.getGlyph(65, false, false); // 'A'
+    if (g) {
+      expect(atlas.cache.size).toBe(188);
+    }
+  });
+
+  it("clearCache re-warms ASCII automatically", () => {
+    const atlas = new GlyphAtlas(14, "monospace");
+    atlas.getGlyph(0x4e2d, false, false); // CJK char (not in prewarm set)
+    atlas.clearCache();
+    const g = atlas.getGlyph(65, false, false);
+    if (g) {
+      // Only ASCII prewarm glyphs — CJK was cleared and not re-warmed
+      expect(atlas.cache.size).toBe(188);
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/web/src/render-worker.ts
+++ b/packages/web/src/render-worker.ts
@@ -971,7 +971,6 @@ function handleMessage(msg: RenderWorkerInboundMessage): void {
       grid = createGridFromSAB(msg.sharedBuffer, cols, rows);
 
       atlas = new GlyphAtlas(Math.round(fontSize * dpr), fontFamily, fontWeight, fontWeightBold);
-      atlas.prewarmASCII();
 
       gl = canvas.getContext("webgl2", {
         alpha: false,
@@ -1017,6 +1016,7 @@ function handleMessage(msg: RenderWorkerInboundMessage): void {
       syncCanvasSize();
       initGLResources();
       ensureInstanceBuffers();
+      atlas.prewarmASCII();
       grid.markAllDirty();
       startRenderLoop();
       break;

--- a/packages/web/src/render-worker.ts
+++ b/packages/web/src/render-worker.ts
@@ -971,6 +971,7 @@ function handleMessage(msg: RenderWorkerInboundMessage): void {
       grid = createGridFromSAB(msg.sharedBuffer, cols, rows);
 
       atlas = new GlyphAtlas(Math.round(fontSize * dpr), fontFamily, fontWeight, fontWeightBold);
+      atlas.prewarmASCII();
 
       gl = canvas.getContext("webgl2", {
         alpha: false,
@@ -1067,6 +1068,7 @@ function handleMessage(msg: RenderWorkerInboundMessage): void {
         atlas.dispose(gl);
       }
       atlas = new GlyphAtlas(Math.round(fontSize * dpr), fontFamily, fontWeight, fontWeightBold);
+      atlas.prewarmASCII();
 
       if (gl) {
         initGLResources();

--- a/packages/web/src/shared-context.ts
+++ b/packages/web/src/shared-context.ts
@@ -274,6 +274,7 @@ export class SharedWebGLContext {
       this.fontWeight,
       this.fontWeightBold,
     );
+    this.atlas.prewarmASCII();
 
     // Pre-allocate instance buffers for batched rendering (all terminals combined)
     const maxCells = 80 * 24 * 4; // start with 4 terminals worth

--- a/packages/web/src/webgl-renderer.ts
+++ b/packages/web/src/webgl-renderer.ts
@@ -228,6 +228,8 @@ export class GlyphAtlas {
     if (this.ctx && this.canvas) {
       this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
     }
+    // Re-warm ASCII so common characters are immediately available
+    this.prewarmASCII();
   }
 
   /**

--- a/packages/web/src/webgl-renderer.ts
+++ b/packages/web/src/webgl-renderer.ts
@@ -202,6 +202,18 @@ export class GlyphAtlas {
   }
 
   /**
+   * Pre-rasterize ASCII printable characters (33-126) in normal and bold
+   * weights so they are atlas-resident before any terminal content arrives.
+   * Eliminates first-frame cache-miss stutter for common text.
+   */
+  prewarmASCII(): void {
+    for (let cp = 33; cp <= 126; cp++) {
+      this.getGlyph(cp, false, false); // normal
+      this.getGlyph(cp, true, false); // bold
+    }
+  }
+
+  /**
    * Clear the glyph cache so all glyphs are re-rasterized on next access.
    * Used when the underlying font changes (e.g., after a web font loads).
    */
@@ -692,6 +704,7 @@ export class WebGLRenderer implements IRenderer {
       this.fontWeight,
       this.fontWeightBold,
     );
+    this.atlas.prewarmASCII();
 
     // Pre-allocate instance buffers for a reasonable default size
     const maxCells = 80 * 24;
@@ -1094,6 +1107,7 @@ export class WebGLRenderer implements IRenderer {
       this.fontWeight,
       this.fontWeightBold,
     );
+    this.atlas.prewarmASCII();
 
     if (this.grid) {
       this.syncCanvasSize();


### PR DESCRIPTION
## Summary

Pre-rasterize ASCII 33-126 in normal + bold weights (188 glyphs) immediately after atlas creation. Ensures common characters are atlas-resident before any terminal content arrives, eliminating first-frame cache-miss stutter.

Part of #168 (glyph atlas optimization). Phase 1 (eliminate getImageData) was shipped in PR #167.

### Changes

- Added `GlyphAtlas.prewarmASCII()` method
- Called after every atlas creation: WebGLRenderer (init + font change), SharedWebGLContext (init), render-worker (init + font change)

### Phase 3 (alpha-only atlas) assessment

Investigated and **deferred** — switching to `GL_R8` conflicts with the Phase 1 optimization. The `texImage2D(canvas)` direct upload only works with RGBA. Using `GL_R8` would require `getImageData()` to extract the alpha channel, reintroducing the CPU readback we just eliminated. The memory savings (4x at 512x512 = 768KB saved) don't justify the throughput regression.

## Benchmark results (Phase 1+2 combined vs Apr 8 baseline)

| Scenario | Before | After | Improvement |
|----------|--------|-------|-------------|
| unicode | 35.3 MB/s | 51.5 MB/s | **+46%** |
| vte-unicode | 5.8 MB/s | 8.2 MB/s | **+41%** |
| sgr-color | 30.3 MB/s | 36.9 MB/s | **+22%** |
| ascii | 36.4 MB/s | 43.9 MB/s | **+21%** |
| real-world | 51.0 MB/s | 56.8 MB/s | **+11%** |
| vte-scrolling-fullscreen | 51.5 MB/s | 56.7 MB/s | **+10%** |
| All others | +1-8% | | No regressions |

## Test plan

- [x] 1715 tests pass
- [x] Type-check clean
- [x] Benchmark confirms improvement with no regressions

Partially addresses #168