### PR TITLE
feat: text reflow on horizontal terminal resize

### DIFF
--- a/packages/core/src/__tests__/buffer.test.ts
+++ b/packages/core/src/__tests__/buffer.test.ts
@@ -306,3 +306,35 @@ describe("BufferSet scrollback", () => {
     expect(bs.maxScrollback).toBe(10);
   });
 });
+
+// ---------------------------------------------------------------------------
+// BufferSet — scrollbackWrap
+// ---------------------------------------------------------------------------
+describe("BufferSet scrollbackWrap", () => {
+  it("pushScrollback stores wrap flag", () => {
+    const bs = new BufferSet(10, 5, 100);
+    const row = new Uint32Array(20);
+    bs.pushScrollback(row, true);
+    expect(bs.scrollbackWrap[0]).toBe(true);
+  });
+
+  it("pushScrollback defaults wrapped to false", () => {
+    const bs = new BufferSet(10, 5, 100);
+    const row = new Uint32Array(20);
+    bs.pushScrollback(row);
+    expect(bs.scrollbackWrap[0]).toBe(false);
+  });
+
+  it("scrollbackWrap evicted in sync with scrollback", () => {
+    const bs = new BufferSet(10, 5, 3); // max 3
+    bs.pushScrollback(new Uint32Array(20), true); // [true]
+    bs.pushScrollback(new Uint32Array(20), false); // [true, false]
+    bs.pushScrollback(new Uint32Array(20), true); // [true, false, true]
+    bs.pushScrollback(new Uint32Array(20), false); // [false, true, false] — first evicted
+    expect(bs.scrollback.length).toBe(3);
+    expect(bs.scrollbackWrap.length).toBe(3);
+    expect(bs.scrollbackWrap[0]).toBe(false);
+    expect(bs.scrollbackWrap[1]).toBe(true);
+    expect(bs.scrollbackWrap[2]).toBe(false);
+  });
+});

--- a/packages/core/src/__tests__/cell-grid.test.ts
+++ b/packages/core/src/__tests__/cell-grid.test.ts
@@ -274,6 +274,78 @@ describe("CellGrid", () => {
   });
 
   // -------------------------------------------------------------------------
+  // Wrap flags
+  // -------------------------------------------------------------------------
+
+  describe("wrapFlags", () => {
+    it("defaults to false for all rows", () => {
+      const grid = new CellGrid(10, 5);
+      for (let r = 0; r < 5; r++) {
+        expect(grid.isWrapped(r)).toBe(false);
+      }
+    });
+
+    it("setWrapped / isWrapped round-trip", () => {
+      const grid = new CellGrid(10, 5);
+      grid.setWrapped(2, true);
+      expect(grid.isWrapped(2)).toBe(true);
+      expect(grid.isWrapped(1)).toBe(false);
+      expect(grid.isWrapped(3)).toBe(false);
+    });
+
+    it("clearRow resets wrap flag", () => {
+      const grid = new CellGrid(10, 5);
+      grid.setWrapped(2, true);
+      grid.clearRow(2);
+      expect(grid.isWrapped(2)).toBe(false);
+    });
+
+    it("clearRowRaw resets wrap flag", () => {
+      const grid = new CellGrid(10, 5);
+      grid.setWrapped(3, true);
+      grid.clearRowRaw(3);
+      expect(grid.isWrapped(3)).toBe(false);
+    });
+
+    it("clear() resets all wrap flags", () => {
+      const grid = new CellGrid(10, 5);
+      grid.setWrapped(0, true);
+      grid.setWrapped(2, true);
+      grid.setWrapped(4, true);
+      grid.clear();
+      for (let r = 0; r < 5; r++) {
+        expect(grid.isWrapped(r)).toBe(false);
+      }
+    });
+
+    it("wrap flags survive rotateUp", () => {
+      const grid = new CellGrid(10, 5);
+      grid.setWrapped(1, true); // logical row 1
+      grid.setWrapped(3, true); // logical row 3
+      grid.rotateUp();
+      // After rotateUp: old logical 1 is now logical 0, old logical 3 is now logical 2
+      expect(grid.isWrapped(0)).toBe(true);
+      expect(grid.isWrapped(2)).toBe(true);
+      // Old logical 0 rotated to logical 4 (the new bottom), but its flag is the old row 0's flag
+      expect(grid.isWrapped(1)).toBe(false);
+      expect(grid.isWrapped(3)).toBe(false);
+    });
+
+    it("wrap flags survive rotateDown", () => {
+      const grid = new CellGrid(10, 5);
+      grid.setWrapped(1, true);
+      grid.setWrapped(3, true);
+      grid.rotateDown();
+      // After rotateDown: old logical 1 is now logical 2, old logical 3 is now logical 4
+      expect(grid.isWrapped(2)).toBe(true);
+      expect(grid.isWrapped(4)).toBe(true);
+      expect(grid.isWrapped(0)).toBe(false);
+      expect(grid.isWrapped(1)).toBe(false);
+      expect(grid.isWrapped(3)).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Wide character flag
   // -------------------------------------------------------------------------
 

--- a/packages/core/src/__tests__/reflow.test.ts
+++ b/packages/core/src/__tests__/reflow.test.ts
@@ -1,0 +1,378 @@
+import { describe, expect, it } from "vitest";
+import { CELL_SIZE, DEFAULT_CELL_W0, DEFAULT_CELL_W1 } from "../cell-grid.js";
+import { MAX_LOGICAL_LINE_LEN, type RowData, reflowRows } from "../reflow.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a RowData from an ASCII string, padded with default cells to `cols`. */
+function makeRow(text: string, cols: number, wrapped = false): RowData {
+  const cells = new Uint32Array(cols * CELL_SIZE);
+  for (let i = 0; i < cols; i++) {
+    const cp = i < text.length ? text.charCodeAt(i) : 0x20;
+    cells[i * CELL_SIZE] = (cp & 0x1fffff) | (7 << 23);
+    cells[i * CELL_SIZE + 1] = 0;
+  }
+  return { cells, wrapped };
+}
+
+/** Create an empty row of `cols` default cells. */
+function emptyRow(cols: number, wrapped = false): RowData {
+  const cells = new Uint32Array(cols * CELL_SIZE);
+  for (let i = 0; i < cols; i++) {
+    cells[i * CELL_SIZE] = DEFAULT_CELL_W0;
+    cells[i * CELL_SIZE + 1] = DEFAULT_CELL_W1;
+  }
+  return { cells, wrapped };
+}
+
+/** Read trimmed text from a RowData. */
+function rowText(row: RowData): string {
+  const cols = row.cells.length / CELL_SIZE;
+  let text = "";
+  for (let c = 0; c < cols; c++) {
+    const cp = row.cells[c * CELL_SIZE] & 0x1fffff;
+    if (cp === 0) continue; // skip spacer cells
+    text += String.fromCodePoint(cp);
+  }
+  return text.replace(/\s+$/, "");
+}
+
+/** Set a wide character at the given column (occupies col and col+1). */
+function setWideChar(cells: Uint32Array, col: number, codepoint: number): void {
+  cells[col * CELL_SIZE] = (codepoint & 0x1fffff) | (7 << 23);
+  cells[col * CELL_SIZE + 1] = 1 << 15; // WIDE bit
+  // Spacer cell
+  cells[(col + 1) * CELL_SIZE] = 0 | (7 << 23); // codepoint 0 = spacer
+  cells[(col + 1) * CELL_SIZE + 1] = 0;
+}
+
+/** Create a row with a wide char at a specific position. */
+function _makeRowWithWide(
+  text: string,
+  wideCol: number,
+  wideCp: number,
+  cols: number,
+  wrapped = false,
+): RowData {
+  const row = makeRow(text, cols, wrapped);
+  setWideChar(row.cells, wideCol, wideCp);
+  return row;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("reflowRows", () => {
+  // ---- Basic shrink ----
+
+  describe("shrink", () => {
+    it("splits a full row into two when shrinking", () => {
+      const rows = [makeRow("ABCDEFGH", 8)];
+      const { reflowed } = reflowRows(rows, 8, 4, 0, 0);
+      expect(reflowed).toHaveLength(2);
+      expect(rowText(reflowed[0])).toBe("ABCD");
+      expect(reflowed[0].wrapped).toBe(true);
+      expect(rowText(reflowed[1])).toBe("EFGH");
+      expect(reflowed[1].wrapped).toBe(false);
+    });
+
+    it("splits into three rows when needed", () => {
+      const rows = [makeRow("ABCDEFGHIJKL", 12)];
+      const { reflowed } = reflowRows(rows, 12, 4, 0, 0);
+      expect(reflowed).toHaveLength(3);
+      expect(rowText(reflowed[0])).toBe("ABCD");
+      expect(reflowed[0].wrapped).toBe(true);
+      expect(rowText(reflowed[1])).toBe("EFGH");
+      expect(reflowed[1].wrapped).toBe(true);
+      expect(rowText(reflowed[2])).toBe("IJKL");
+      expect(reflowed[2].wrapped).toBe(false);
+    });
+
+    it("does not split a short row", () => {
+      const rows = [makeRow("AB", 8)];
+      const { reflowed } = reflowRows(rows, 8, 4, 0, 0);
+      expect(reflowed).toHaveLength(1);
+      expect(rowText(reflowed[0])).toBe("AB");
+      expect(reflowed[0].wrapped).toBe(false);
+    });
+  });
+
+  // ---- Basic expand ----
+
+  describe("expand", () => {
+    it("merges two wrapped rows into one", () => {
+      const rows = [makeRow("ABCD", 4, true), makeRow("EFGH", 4)];
+      const { reflowed } = reflowRows(rows, 4, 8, 0, 0);
+      expect(reflowed).toHaveLength(1);
+      expect(rowText(reflowed[0])).toBe("ABCDEFGH");
+      expect(reflowed[0].wrapped).toBe(false);
+    });
+
+    it("merges three wrapped rows into fewer rows", () => {
+      const rows = [makeRow("ABCD", 4, true), makeRow("EFGH", 4, true), makeRow("IJKL", 4)];
+      const { reflowed } = reflowRows(rows, 4, 8, 0, 0);
+      expect(reflowed).toHaveLength(2);
+      expect(rowText(reflowed[0])).toBe("ABCDEFGH");
+      expect(reflowed[0].wrapped).toBe(true);
+      expect(rowText(reflowed[1])).toBe("IJKL");
+      expect(reflowed[1].wrapped).toBe(false);
+    });
+
+    it("merges three wrapped rows into one when wide enough", () => {
+      const rows = [makeRow("ABCD", 4, true), makeRow("EFGH", 4, true), makeRow("IJKL", 4)];
+      const { reflowed } = reflowRows(rows, 4, 12, 0, 0);
+      expect(reflowed).toHaveLength(1);
+      expect(rowText(reflowed[0])).toBe("ABCDEFGHIJKL");
+    });
+  });
+
+  // ---- Round-trip ----
+
+  describe("round-trip", () => {
+    it("shrink then expand preserves text", () => {
+      const original = [makeRow("ABCDEFGH", 8)];
+      const shrunk = reflowRows(original, 8, 4, 0, 0);
+      const expanded = reflowRows(shrunk.reflowed, 4, 8, 0, 0);
+      expect(expanded.reflowed).toHaveLength(1);
+      expect(rowText(expanded.reflowed[0])).toBe("ABCDEFGH");
+    });
+
+    it("80→40→80 round-trip preserves long text", () => {
+      const text = "A".repeat(80);
+      const original = [makeRow(text, 80)];
+      const shrunk = reflowRows(original, 80, 40, 0, 0);
+      expect(shrunk.reflowed).toHaveLength(2);
+      const expanded = reflowRows(shrunk.reflowed, 40, 80, 0, 0);
+      expect(expanded.reflowed).toHaveLength(1);
+      expect(rowText(expanded.reflowed[0])).toBe(text);
+    });
+  });
+
+  // ---- No change ----
+
+  describe("no column change", () => {
+    it("returns same rows when cols unchanged", () => {
+      const rows = [makeRow("ABCD", 4, true), makeRow("EF", 4)];
+      const { reflowed } = reflowRows(rows, 4, 4, 0, 0);
+      expect(reflowed).toHaveLength(2);
+      expect(rowText(reflowed[0])).toBe("ABCD");
+      expect(reflowed[0].wrapped).toBe(true);
+      expect(rowText(reflowed[1])).toBe("EF");
+      expect(reflowed[1].wrapped).toBe(false);
+    });
+  });
+
+  // ---- Hard breaks ----
+
+  describe("hard breaks", () => {
+    it("preserves hard breaks (unwrapped rows)", () => {
+      const rows = [makeRow("ABCD", 8), makeRow("EFGH", 8)]; // both wrapped=false
+      const { reflowed } = reflowRows(rows, 8, 4, 0, 0);
+      // "ABCD" fits in 4 cols → 1 row. "EFGH" fits in 4 cols → 1 row.
+      expect(reflowed).toHaveLength(2);
+      expect(rowText(reflowed[0])).toBe("ABCD");
+      expect(reflowed[0].wrapped).toBe(false);
+      expect(rowText(reflowed[1])).toBe("EFGH");
+      expect(reflowed[1].wrapped).toBe(false);
+    });
+
+    it("does not merge unwrapped rows on expand", () => {
+      const rows = [makeRow("AB", 4), makeRow("CD", 4)]; // both wrapped=false
+      const { reflowed } = reflowRows(rows, 4, 8, 0, 0);
+      expect(reflowed).toHaveLength(2);
+      expect(rowText(reflowed[0])).toBe("AB");
+      expect(rowText(reflowed[1])).toBe("CD");
+    });
+  });
+
+  // ---- Empty rows ----
+
+  describe("empty rows", () => {
+    it("passes through empty rows unchanged", () => {
+      const rows = [emptyRow(8), emptyRow(8)];
+      const { reflowed } = reflowRows(rows, 8, 4, 0, 0);
+      expect(reflowed).toHaveLength(2);
+      expect(rowText(reflowed[0])).toBe("");
+      expect(rowText(reflowed[1])).toBe("");
+    });
+
+    it("does not merge empty row with adjacent content", () => {
+      const rows = [makeRow("ABCD", 8), emptyRow(8), makeRow("EFGH", 8)];
+      const { reflowed } = reflowRows(rows, 8, 4, 0, 0);
+      expect(reflowed).toHaveLength(3);
+      expect(rowText(reflowed[0])).toBe("ABCD");
+      expect(rowText(reflowed[1])).toBe("");
+      expect(rowText(reflowed[2])).toBe("EFGH");
+    });
+  });
+
+  // ---- Empty input ----
+
+  describe("empty input", () => {
+    it("handles empty array", () => {
+      const { reflowed } = reflowRows([], 80, 40, 0, 0);
+      expect(reflowed).toHaveLength(0);
+    });
+  });
+
+  // ---- Wide characters ----
+
+  describe("wide characters", () => {
+    it("does not split wide char pair at shrink boundary", () => {
+      // Row: A B [WIDE+SPACER] E → 5 cells
+      const row = makeRow("AB E", 5);
+      setWideChar(row.cells, 2, 0x4e2d); // 中 at col 2-3
+      // fill col 4 with 'E'
+      row.cells[4 * CELL_SIZE] = (0x45 & 0x1fffff) | (7 << 23);
+      row.cells[4 * CELL_SIZE + 1] = 0;
+
+      const { reflowed } = reflowRows([row], 5, 3, 0, 0);
+      // At width 3: "AB" fits, then wide char at col 2 would be split → push to next row
+      expect(reflowed.length).toBeGreaterThanOrEqual(2);
+      // First row should have "AB" (the wide char didn't fit at col 2 in 3-wide row)
+      expect(reflowed[0].wrapped).toBe(true);
+    });
+
+    it("handles wide char at the end of a row during expand", () => {
+      // Two 4-col rows: "AB[W]" (wrapped) + "CD"
+      const row1 = makeRow("AB", 4, true);
+      setWideChar(row1.cells, 2, 0x4e2d); // 中 at col 2-3
+      const row2 = makeRow("CD", 4);
+
+      const { reflowed } = reflowRows([row1, row2], 4, 8, 0, 0);
+      expect(reflowed).toHaveLength(1);
+      // Should have: A B 中 _ C D
+      const text = rowText(reflowed[0]);
+      expect(text).toContain("AB");
+      expect(text).toContain("CD");
+    });
+  });
+
+  // ---- MAX_LOGICAL_LINE_LEN ----
+
+  describe("MAX_LOGICAL_LINE_LEN", () => {
+    it("caps logical lines at MAX_LOGICAL_LINE_LEN", () => {
+      // Create a very long wrapped sequence
+      const longRows: RowData[] = [];
+      const rowsNeeded = MAX_LOGICAL_LINE_LEN + 100;
+      for (let i = 0; i < rowsNeeded; i++) {
+        longRows.push(makeRow("X", 1, i < rowsNeeded - 1));
+      }
+      const { reflowed } = reflowRows(longRows, 1, 1, 0, 0);
+      // Should produce at least 2 logical lines due to capping
+      expect(reflowed.length).toBeLessThanOrEqual(rowsNeeded);
+      // No crash is the main test
+      expect(reflowed.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ---- Cursor tracking ----
+
+  describe("cursor tracking", () => {
+    it("tracks cursor through shrink", () => {
+      // "ABCDEFGH" at 8 cols, cursor at col 5 (on 'F')
+      const rows = [makeRow("ABCDEFGH", 8)];
+      const { newCursorRow, newCursorCol } = reflowRows(rows, 8, 4, 0, 5);
+      // After shrink to 4: "ABCD" (row 0), "EFGH" (row 1)
+      // Cursor was at col 5 → now at row 1, col 1
+      expect(newCursorRow).toBe(1);
+      expect(newCursorCol).toBe(1);
+    });
+
+    it("tracks cursor through expand", () => {
+      // "ABCD" (wrapped) + "EFGH" at 4 cols, cursor at row 1 col 2 (on 'G')
+      const rows = [makeRow("ABCD", 4, true), makeRow("EFGH", 4)];
+      const { newCursorRow, newCursorCol } = reflowRows(rows, 4, 8, 1, 2);
+      // After expand to 8: "ABCDEFGH" (row 0)
+      // Cursor was at row 1 col 2 → logical offset = 4 + 2 = 6 → row 0, col 6
+      expect(newCursorRow).toBe(0);
+      expect(newCursorCol).toBe(6);
+    });
+
+    it("clamps cursor past content to end of row", () => {
+      const rows = [makeRow("AB", 8)];
+      const { newCursorRow, newCursorCol } = reflowRows(rows, 8, 4, 0, 7);
+      // Content is only "AB" (2 chars). Cursor at col 7.
+      // After shrink: single row "AB". Cursor clamped to col 3 (max for 4-col row)
+      expect(newCursorRow).toBe(0);
+      expect(newCursorCol).toBeLessThan(4);
+    });
+
+    it("cursor at row 0 col 0 stays at 0,0", () => {
+      const rows = [makeRow("ABCD", 4)];
+      const { newCursorRow, newCursorCol } = reflowRows(rows, 4, 8, 0, 0);
+      expect(newCursorRow).toBe(0);
+      expect(newCursorCol).toBe(0);
+    });
+
+    it("cursor tracks through MAX_LOGICAL_LINE_LEN split", () => {
+      // Create a logical line that exceeds MAX_LOGICAL_LINE_LEN
+      const rowsData: RowData[] = [];
+      const totalRows = MAX_LOGICAL_LINE_LEN + 10;
+      for (let i = 0; i < totalRows; i++) {
+        rowsData.push(makeRow("X", 1, i < totalRows - 1));
+      }
+      // Place cursor in the overflow portion (past the cap)
+      const cursorRow = MAX_LOGICAL_LINE_LEN + 5;
+      const { newCursorRow, newCursorCol } = reflowRows(rowsData, 1, 2, cursorRow, 0);
+      // Cursor should be reachable (not lost)
+      expect(newCursorRow).toBeGreaterThanOrEqual(0);
+      expect(newCursorCol).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  // ---- Variable-width scrollback ----
+
+  describe("variable-width scrollback", () => {
+    it("handles rows with different cell array lengths", () => {
+      // Simulate scrollback from a prior resize: row at 6 cols + row at 4 cols
+      const rows = [
+        makeRow("ABCDEF", 6, true), // old width = 6
+        makeRow("GH", 4), // current width = 4
+      ];
+      const { reflowed } = reflowRows(rows, 4, 8, 0, 0);
+      // Logical line: "ABCDEF" + "GH" = "ABCDEFGH"
+      expect(reflowed).toHaveLength(1);
+      expect(rowText(reflowed[0])).toBe("ABCDEFGH");
+    });
+  });
+
+  // ---- Single character ----
+
+  describe("single character", () => {
+    it("single char row survives shrink", () => {
+      const rows = [makeRow("A", 80)];
+      const { reflowed } = reflowRows(rows, 80, 40, 0, 0);
+      expect(reflowed).toHaveLength(1);
+      expect(rowText(reflowed[0])).toBe("A");
+      expect(reflowed[0].wrapped).toBe(false);
+    });
+  });
+
+  // ---- Mixed wrapped and unwrapped ----
+
+  describe("mixed wrapped and unwrapped", () => {
+    it("handles [wrap][wrap][no-wrap][wrap][no-wrap]", () => {
+      const rows = [
+        makeRow("AAAA", 4, true), // logical line 1 start
+        makeRow("BBBB", 4, true), // logical line 1 cont
+        makeRow("CCCC", 4, false), // logical line 1 end
+        makeRow("DDDD", 4, true), // logical line 2 start
+        makeRow("EEEE", 4, false), // logical line 2 end
+      ];
+      const { reflowed } = reflowRows(rows, 4, 8, 0, 0);
+      // Logical line 1: AAAABBBBCCCC → 12 chars / 8 cols = 2 rows
+      // Logical line 2: DDDDEEEE → 8 chars / 8 cols = 1 row
+      expect(reflowed).toHaveLength(3);
+      expect(rowText(reflowed[0])).toBe("AAAABBBB");
+      expect(reflowed[0].wrapped).toBe(true);
+      expect(rowText(reflowed[1])).toBe("CCCC");
+      expect(reflowed[1].wrapped).toBe(false);
+      expect(rowText(reflowed[2])).toBe("DDDDEEEE");
+      expect(reflowed[2].wrapped).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/buffer.ts
+++ b/packages/core/src/buffer.ts
@@ -72,6 +72,7 @@ export class Buffer {
         const dst = this.grid.rowStart(r);
         const src = this.grid.rowStart(r + 1);
         this.grid.data.copyWithin(dst, src, src + rowSize);
+        this.grid.setWrapped(r, this.grid.isWrapped(r + 1));
       }
       this.grid.clearRowRaw(this.scrollBottom);
       this.grid.markDirtyRange(this.scrollTop, this.scrollBottom);
@@ -94,6 +95,7 @@ export class Buffer {
         const dst = this.grid.rowStart(r);
         const src = this.grid.rowStart(r - 1);
         this.grid.data.copyWithin(dst, src, src + rowSize);
+        this.grid.setWrapped(r, this.grid.isWrapped(r - 1));
       }
       this.grid.clearRowRaw(this.scrollTop);
       this.grid.markDirtyRange(this.scrollTop, this.scrollBottom);
@@ -108,6 +110,8 @@ export class BufferSet {
 
   /** Scrollback lines for the normal buffer (array of Uint32Array). */
   scrollback: Uint32Array[];
+  /** Per-line wrap flag for scrollback (parallel to scrollback[]). */
+  scrollbackWrap: boolean[];
   readonly maxScrollback: number;
 
   constructor(
@@ -125,6 +129,7 @@ export class BufferSet {
       : new Buffer(cols, rows);
     this.active = this.normal;
     this.scrollback = [];
+    this.scrollbackWrap = [];
     this.maxScrollback = maxScrollback;
   }
 
@@ -164,10 +169,12 @@ export class BufferSet {
    * returns scrollback[0] which the caller fills before calling this.
    * Reversing the order would evict the buffer before it's appended.
    */
-  pushScrollback(line: Uint32Array): void {
+  pushScrollback(line: Uint32Array, wrapped = false): void {
     this.scrollback.push(line);
+    this.scrollbackWrap.push(wrapped);
     if (this.scrollback.length > this.maxScrollback) {
       this.scrollback.shift();
+      this.scrollbackWrap.shift();
     }
   }
 
@@ -192,7 +199,8 @@ export class BufferSet {
       const rowSize = grid.cols * CELL_SIZE;
       const dest = this.borrowRowBuffer(rowSize);
       grid.copyRowInto(0, dest);
-      this.pushScrollback(dest);
+      const wasWrapped = grid.isWrapped(0);
+      this.pushScrollback(dest, wasWrapped);
     }
     this.active.scrollUp();
   }

--- a/packages/core/src/cell-grid.ts
+++ b/packages/core/src/cell-grid.ts
@@ -44,6 +44,8 @@ export class CellGrid {
    */
   readonly rowOffsetData: Int32Array;
 
+  readonly wrapFlags: Int32Array;
+
   constructor(cols: number, rows: number, existingBuffer?: SharedArrayBuffer) {
     this.cols = cols;
     this.rows = rows;
@@ -53,6 +55,7 @@ export class CellGrid {
     const rgbBytes = 512 * 4;
     const cursorBytes = 4 * 4; // 4 x Int32: row, col, visible, style
     const offsetBytes = 1 * 4; // 1 x Int32: row offset for circular buffer
+    const wrapBytes = rows * 4; // Int32Array: 1 per row for wrap flags
 
     if (existingBuffer) {
       // Create views over an existing SharedArrayBuffer (used by workers
@@ -60,7 +63,7 @@ export class CellGrid {
       this.buffer = existingBuffer;
       this.isShared = true;
     } else {
-      const totalBytes = cellBytes + dirtyBytes + rgbBytes + cursorBytes + offsetBytes;
+      const totalBytes = cellBytes + dirtyBytes + rgbBytes + cursorBytes + offsetBytes + wrapBytes;
       const BufferType = SAB_AVAILABLE ? SharedArrayBuffer : ArrayBuffer;
       this.buffer = new BufferType(totalBytes);
       this.isShared = SAB_AVAILABLE;
@@ -74,6 +77,11 @@ export class CellGrid {
       this.buffer,
       cellBytes + dirtyBytes + rgbBytes + cursorBytes,
       1,
+    );
+    this.wrapFlags = new Int32Array(
+      this.buffer,
+      cellBytes + dirtyBytes + rgbBytes + cursorBytes + offsetBytes,
+      rows,
     );
 
     // Build a template row: each cell is a space with default fg=7
@@ -113,6 +121,25 @@ export class CellGrid {
   rotateDown(n = 1): void {
     const v = this.rowOffsetData[0] - (n % this.rows);
     this.rowOffsetData[0] = v < 0 ? v + this.rows : v;
+  }
+
+  /** True if logical row `row` soft-wraps into row+1. */
+  isWrapped(row: number): boolean {
+    const phys = this.physicalRow(row);
+    if (this.isShared) {
+      return Atomics.load(this.wrapFlags, phys) !== 0;
+    }
+    return this.wrapFlags[phys] !== 0;
+  }
+
+  /** Set whether logical row `row` soft-wraps into row+1. */
+  setWrapped(row: number, wrapped: boolean): void {
+    const phys = this.physicalRow(row);
+    if (this.isShared) {
+      Atomics.store(this.wrapFlags, phys, wrapped ? 1 : 0);
+    } else {
+      this.wrapFlags[phys] = wrapped ? 1 : 0;
+    }
   }
 
   getCodepoint(row: number, col: number): number {
@@ -230,6 +257,7 @@ export class CellGrid {
 
   clear(): void {
     this.rowOffsetData[0] = 0;
+    this.wrapFlags.fill(0);
     for (let r = 0; r < this.rows; r++) {
       this.data.set(this._templateRow, r * this.cols * CELL_SIZE);
     }
@@ -250,7 +278,7 @@ export class CellGrid {
   }
 
   /** Overwrite a logical row from a previously copied Uint32Array. */
-  pasteRow(row: number, src: Uint32Array): void {
+  pasteRow(row: number, src: Uint32Array, wrapped?: boolean): void {
     const start = this.rowStart(row);
     const rowLen = this.cols * CELL_SIZE;
     if (src.length <= rowLen) {
@@ -259,6 +287,9 @@ export class CellGrid {
       // Source row is wider than this grid — only copy what fits
       this.data.set(src.subarray(0, rowLen), start);
     }
+    if (wrapped !== undefined) {
+      this.setWrapped(row, wrapped);
+    }
     this.markDirty(row);
   }
 
@@ -266,12 +297,14 @@ export class CellGrid {
   clearRow(row: number): void {
     const start = this.rowStart(row);
     this.data.set(this._templateRow, start);
+    this.setWrapped(row, false);
     this.markDirty(row);
   }
 
   /** Fill a logical row with defaults without marking dirty (caller will batch-mark). */
   clearRowRaw(row: number): void {
     this.data.set(this._templateRow, this.rowStart(row));
+    this.setWrapped(row, false);
   }
 
   // ---- Cursor in SAB -------------------------------------------------------
@@ -394,7 +427,14 @@ export function extractText(
     }
 
     // Trim trailing spaces
-    lines.push(line.replace(/\s+$/, ""));
+    line = line.replace(/\s+$/, "");
+
+    // If previous row wraps into this one, append without newline
+    if (row > sr && grid.isWrapped(row - 1)) {
+      lines[lines.length - 1] += line;
+    } else {
+      lines.push(line);
+    }
   }
 
   return lines.join("\n");

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,8 @@ export { GestureHandler, GestureState } from "./gesture-handler.js";
 export type { MouseEncoding, MouseProtocol } from "./parser/index.js";
 export { VTParser } from "./parser/index.js";
 export { Action, State, TABLE, unpackAction, unpackState } from "./parser/states.js";
+export type { ReflowResult, RowData } from "./reflow.js";
+export { MAX_LOGICAL_LINE_LEN, reflowRows } from "./reflow.js";
 export type { CursorState, SelectionState, TerminalOptions, Theme } from "./types.js";
 export { DEFAULT_THEME, DirtyState } from "./types.js";
 export { isCombining, wcwidth } from "./wcwidth.js";

--- a/packages/core/src/parser/index.ts
+++ b/packages/core/src/parser/index.ts
@@ -608,6 +608,7 @@ export class VTParser {
           if (cursor.wrapPending) {
             cursor.wrapPending = false;
             if (this.autoWrapMode) {
+              grid.setWrapped(cachedRow, true);
               grid.markDirty(cachedRow);
               cursor.col = 0;
               cursor.row++;
@@ -626,6 +627,7 @@ export class VTParser {
             // Fill current cell with space, then wrap
             gridData[cellIdx] = 0x20 | word0Base;
             gridData[cellIdx + 1] = word1;
+            grid.setWrapped(cachedRow, true);
             grid.markDirty(cachedRow);
             cursor.col = 0;
             cursor.row++;
@@ -848,6 +850,7 @@ export class VTParser {
     if (cursor.wrapPending) {
       cursor.wrapPending = false;
       if (this.autoWrapMode) {
+        grid.setWrapped(cursor.row, true);
         cursor.col = 0;
         cursor.row++;
         if (cursor.row > buf.scrollBottom) {
@@ -872,6 +875,7 @@ export class VTParser {
         0x20 | (this.fgIsRGB ? 1 << 21 : 0) | (this.bgIsRGB ? 1 << 22 : 0) | ((fgVal & 0xff) << 23);
       grid.data[idx + 1] =
         ((this.bgIsRGB ? this.bgRGB & 0xff : this.bgIndex) & 0xff) | ((this.attrs & 0xff) << 8);
+      grid.setWrapped(cursor.row, true);
       grid.markDirty(cursor.row);
 
       cursor.col = 0;
@@ -977,7 +981,8 @@ export class VTParser {
         const rowSize = grid.cols * CELL_SIZE;
         const dest = this.bufferSet.borrowRowBuffer(rowSize);
         grid.copyRowInto(0, dest);
-        this.bufferSet.pushScrollback(dest);
+        const wasWrapped = grid.isWrapped(0);
+        this.bufferSet.pushScrollback(dest, wasWrapped);
       }
       grid.rotateUp();
       grid.clearRowRaw(buf.scrollBottom);
@@ -1872,6 +1877,7 @@ export class VTParser {
       const src = grid.rowStart(r - n);
       const dst = grid.rowStart(r);
       grid.data.copyWithin(dst, src, src + rowSize);
+      grid.setWrapped(r, grid.isWrapped(r - n));
     }
     // Clear the n inserted rows
     for (let r = cursor.row; r < cursor.row + n; r++) {
@@ -1892,6 +1898,7 @@ export class VTParser {
       const src = grid.rowStart(r + n);
       const dst = grid.rowStart(r);
       grid.data.copyWithin(dst, src, src + rowSize);
+      grid.setWrapped(r, grid.isWrapped(r + n));
     }
     // Clear the n vacated rows at the bottom
     for (let r = this.buf.scrollBottom - n + 1; r <= this.buf.scrollBottom; r++) {

--- a/packages/core/src/reflow.ts
+++ b/packages/core/src/reflow.ts
@@ -1,0 +1,244 @@
+import { CELL_SIZE, DEFAULT_CELL_W0, DEFAULT_CELL_W1 } from "./cell-grid.js";
+
+export const MAX_LOGICAL_LINE_LEN = 4096;
+const WIDE_BIT = 1 << 15; // Word 1 bit 15
+
+export interface RowData {
+  cells: Uint32Array;
+  wrapped: boolean;
+}
+
+export interface ReflowResult {
+  reflowed: RowData[];
+  newCursorRow: number;
+  newCursorCol: number;
+}
+
+/** Check if a cell at the given position is a default (empty) cell. */
+function isDefaultCell(cells: Uint32Array, cellIndex: number): boolean {
+  const offset = cellIndex * CELL_SIZE;
+  return cells[offset] === DEFAULT_CELL_W0 && cells[offset + 1] === DEFAULT_CELL_W1;
+}
+
+/** Find the last non-default cell index + 1 (content length) in a row. */
+function contentLength(cells: Uint32Array, cols: number): number {
+  for (let i = cols - 1; i >= 0; i--) {
+    if (!isDefaultCell(cells, i)) {
+      return i + 1;
+    }
+  }
+  return 0;
+}
+
+/** Safety cap on total output rows to prevent OOM when shrinking to very
+ *  narrow widths (e.g., 200-col scrollback reflowed to 2 cols = 100× expansion). */
+const MAX_OUTPUT_ROWS = 200_000;
+
+export function reflowRows(
+  rows: RowData[],
+  oldCols: number,
+  newCols: number,
+  cursorAbsRow: number,
+  cursorCol: number,
+): ReflowResult {
+  // Empty input
+  if (rows.length === 0) {
+    return { reflowed: [], newCursorRow: 0, newCursorCol: 0 };
+  }
+
+  // No change in width — return rows unchanged with cursor fixed
+  if (newCols === oldCols) {
+    const clampedRow = Math.min(cursorAbsRow, rows.length - 1);
+    const rowCols = rows[clampedRow].cells.length / CELL_SIZE;
+    const clampedCol = Math.min(cursorCol, rowCols - 1);
+    return {
+      reflowed: rows.map((r) => ({ cells: new Uint32Array(r.cells), wrapped: r.wrapped })),
+      newCursorRow: clampedRow,
+      newCursorCol: Math.max(0, clampedCol),
+    };
+  }
+
+  // ---- Phase 1: JOIN — group physical rows into logical lines ----
+  interface LogicalLine {
+    cells: Uint32Array;
+    length: number; // number of cells used
+    cursorOffset: number; // cursor offset within this logical line, or -1
+  }
+
+  const logicalLines: LogicalLine[] = [];
+  const currentCells = new Uint32Array(MAX_LOGICAL_LINE_LEN * CELL_SIZE);
+  let currentLen = 0;
+  let currentCursorOffset = -1;
+
+  function flushLogicalLine(): void {
+    // Copy only the used portion
+    const trimmed = new Uint32Array(currentCells.buffer, 0, currentLen * CELL_SIZE).slice();
+    logicalLines.push({
+      cells: trimmed,
+      length: currentLen,
+      cursorOffset: currentCursorOffset,
+    });
+    currentLen = 0;
+    currentCursorOffset = -1;
+  }
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    const rowCols = row.cells.length / CELL_SIZE;
+    const isLastOfLogical = !row.wrapped;
+
+    // Track cursor before appending
+    if (i === cursorAbsRow) {
+      currentCursorOffset = currentLen + cursorCol;
+    }
+
+    // Determine how many cells to append from this row
+    let appendLen: number;
+    if (isLastOfLogical) {
+      // Last row of a logical line — trim trailing defaults
+      appendLen = contentLength(row.cells, rowCols);
+    } else {
+      // Internal wrapped row — use full width (it wrapped because it was full)
+      appendLen = rowCols;
+    }
+
+    // Check if appending would exceed MAX_LOGICAL_LINE_LEN
+    if (currentLen + appendLen > MAX_LOGICAL_LINE_LEN) {
+      // Append what we can
+      const canFit = MAX_LOGICAL_LINE_LEN - currentLen;
+      if (canFit > 0) {
+        currentCells.set(row.cells.subarray(0, canFit * CELL_SIZE), currentLen * CELL_SIZE);
+        currentLen += canFit;
+      }
+      flushLogicalLine();
+
+      // Remainder goes into a new logical line
+      const remainder = appendLen - canFit;
+      if (remainder > 0) {
+        currentCells.set(
+          row.cells.subarray(canFit * CELL_SIZE, (canFit + remainder) * CELL_SIZE),
+          0,
+        );
+        currentLen = remainder;
+      }
+
+      // Fix cursor offset if it was in this row and got split across
+      // the MAX_LOGICAL_LINE_LEN boundary.
+      if (i === cursorAbsRow) {
+        if (cursorCol < canFit) {
+          // Cursor landed in the flushed line — already captured by
+          // flushLogicalLine() via currentCursorOffset (set at line 88).
+          currentCursorOffset = -1;
+        } else {
+          // Cursor is in the remainder portion
+          currentCursorOffset = cursorCol - canFit;
+        }
+      }
+
+      if (isLastOfLogical) {
+        flushLogicalLine();
+      }
+    } else {
+      // Append cells
+      if (appendLen > 0) {
+        currentCells.set(row.cells.subarray(0, appendLen * CELL_SIZE), currentLen * CELL_SIZE);
+        currentLen += appendLen;
+      }
+
+      if (isLastOfLogical) {
+        flushLogicalLine();
+      }
+    }
+  }
+
+  // If there's a dangling logical line (shouldn't happen if last row has wrapped=false,
+  // but handle defensively)
+  if (currentLen > 0 || currentCursorOffset >= 0) {
+    flushLogicalLine();
+  }
+
+  // ---- Phase 2 & 3: TRIM + SPLIT ----
+  const result: RowData[] = [];
+  let newCursorRow = 0;
+  let newCursorCol = 0;
+
+  for (const line of logicalLines) {
+    // Phase 2 — find actual content length
+    let lineContentLen = 0;
+    for (let i = line.length - 1; i >= 0; i--) {
+      if (!isDefaultCell(line.cells, i)) {
+        lineContentLen = i + 1;
+        break;
+      }
+    }
+
+    // If empty line, emit one empty unwrapped row
+    if (lineContentLen === 0) {
+      const emptyCells = new Uint32Array(newCols * CELL_SIZE);
+      for (let c = 0; c < newCols; c++) {
+        emptyCells[c * CELL_SIZE] = DEFAULT_CELL_W0;
+        emptyCells[c * CELL_SIZE + 1] = DEFAULT_CELL_W1;
+      }
+      if (line.cursorOffset >= 0) {
+        newCursorRow = result.length;
+        newCursorCol = Math.min(line.cursorOffset, newCols - 1);
+      }
+      result.push({ cells: emptyCells, wrapped: false });
+      continue;
+    }
+
+    // Phase 3 — split into newCols-wide chunks
+    let pos = 0;
+    while (pos < lineContentLen && result.length < MAX_OUTPUT_ROWS) {
+      let chunkEnd = Math.min(pos + newCols, lineContentLen);
+
+      // Check for wide char at chunk boundary
+      if (chunkEnd < lineContentLen && chunkEnd > pos) {
+        // Check if the last cell of the chunk has the WIDE bit
+        const lastCellIdx = chunkEnd - 1;
+        const w1 = line.cells[lastCellIdx * CELL_SIZE + 1];
+        if (w1 & WIDE_BIT) {
+          // Don't split the wide char pair — reduce chunk by 1
+          chunkEnd--;
+        }
+      }
+
+      // Ensure we make progress (at minimum 1 cell per chunk)
+      if (chunkEnd <= pos) {
+        chunkEnd = pos + 1;
+      }
+
+      const chunkLen = chunkEnd - pos;
+      const rowCells = new Uint32Array(newCols * CELL_SIZE);
+
+      // Copy chunk cells
+      rowCells.set(line.cells.subarray(pos * CELL_SIZE, chunkEnd * CELL_SIZE), 0);
+
+      // Fill remaining cells with defaults
+      for (let c = chunkLen; c < newCols; c++) {
+        rowCells[c * CELL_SIZE] = DEFAULT_CELL_W0;
+        rowCells[c * CELL_SIZE + 1] = DEFAULT_CELL_W1;
+      }
+
+      // Determine if this chunk is wrapped (all chunks except the last of the logical line)
+      const isLastChunk = chunkEnd >= lineContentLen;
+
+      // Cursor tracking
+      if (line.cursorOffset >= 0) {
+        if (line.cursorOffset >= pos && line.cursorOffset < chunkEnd) {
+          newCursorRow = result.length;
+          newCursorCol = line.cursorOffset - pos;
+        } else if (isLastChunk && line.cursorOffset >= chunkEnd) {
+          // Cursor past content — clamp to end of last row of its logical line
+          newCursorRow = result.length;
+          newCursorCol = Math.min(line.cursorOffset - pos, newCols - 1);
+        }
+      }
+
+      result.push({ cells: rowCells, wrapped: !isLastChunk });
+      pos = chunkEnd;
+    }
+  }
+
+  return { reflowed: result, newCursorRow, newCursorCol };
+}

--- a/packages/e2e-bench/tests/integration-scenarios.spec.ts
+++ b/packages/e2e-bench/tests/integration-scenarios.spec.ts
@@ -564,4 +564,176 @@ test.describe('integration scenarios', () => {
       expect(typeof modes.sendFocusEvents).toBe('boolean');
     });
   });
+
+  // =========================================================================
+  // Scenario 11: Text reflow on horizontal resize (#170)
+  // =========================================================================
+  test.describe('text reflow', () => {
+
+    test('shrink and expand preserves text via reflow', async ({ page }) => {
+      // Write a line that fills 80 cols
+      const line = 'ABCDEFGHIJ'.repeat(8); // 80 chars
+      await write(page, line + '\r\n');
+      await waitForContent(page, 'ABCDEFGHIJ');
+
+      // Shrink to 40 cols — should wrap into 2 rows
+      await page.evaluate(() => window.__termRef?.resize(40, 24));
+      await waitForRender(page);
+
+      let rows = await readRows(page);
+      let allText = rows.join('');
+      // All 80 characters should still be present (reflowed across rows)
+      expect(allText).toContain('ABCDEFGHIJ'.repeat(8));
+
+      // Expand back to 80 cols — should merge back into 1 row
+      await page.evaluate(() => window.__termRef?.resize(80, 24));
+      await waitForRender(page);
+
+      rows = await readRows(page);
+      allText = rows.join('');
+      expect(allText).toContain('ABCDEFGHIJ'.repeat(8));
+    });
+
+    test('hard newlines are preserved through reflow', async ({ page }) => {
+      await write(page, 'LINE_ONE\r\n');
+      await write(page, 'LINE_TWO\r\n');
+      await write(page, 'LINE_THREE\r\n');
+      await waitForContent(page, 'LINE_THREE');
+
+      // Shrink — short lines should NOT merge
+      await page.evaluate(() => window.__termRef?.resize(40, 24));
+      await waitForRender(page);
+
+      const rows = await readRows(page);
+      // Each line should still be separate (not concatenated)
+      const lineOneRow = rows.findIndex(r => r.includes('LINE_ONE'));
+      const lineTwoRow = rows.findIndex(r => r.includes('LINE_TWO'));
+      const lineThreeRow = rows.findIndex(r => r.includes('LINE_THREE'));
+      expect(lineOneRow).toBeGreaterThanOrEqual(0);
+      expect(lineTwoRow).toBeGreaterThan(lineOneRow);
+      expect(lineThreeRow).toBeGreaterThan(lineTwoRow);
+    });
+
+    test('reflow survives writes between shrink and expand (SIGWINCH sim)', async ({ page }) => {
+      // Simulate what happens with a PTY: output fills the screen, then
+      // the shell sends a prompt redraw after SIGWINCH between resize events.
+      const line = 'ABCDEFGHIJ'.repeat(8); // 80 chars
+      await write(page, line + '\r\n');
+      await write(page, 'SECOND_LINE_HERE\r\n');
+      await waitForContent(page, 'SECOND_LINE');
+
+      // Shrink to 40 cols
+      await page.evaluate(() => window.__termRef?.resize(40, 24));
+      await waitForRender(page);
+
+      // Simulate shell SIGWINCH response: write at cursor position
+      await write(page, 'PROMPT> ');
+      await waitForRender(page);
+
+      // Expand back to 80 cols
+      await page.evaluate(() => window.__termRef?.resize(80, 24));
+      await waitForRender(page);
+
+      const rows = await readRows(page);
+      const allText = rows.join('');
+      // The original 80-char line should be fully restored (rejoined)
+      expect(allText).toContain('ABCDEFGHIJ'.repeat(8));
+      expect(allText).toContain('SECOND_LINE_HERE');
+    });
+
+    test('reflow survives erase-below after shrink (aggressive SIGWINCH)', async ({ page }) => {
+      // Simulate an aggressive shell SIGWINCH: cursor to prompt row + erase below
+      for (let i = 0; i < 10; i++) {
+        await write(page, `LINE_${String(i).padStart(2, '0')}_${'X'.repeat(65)}\r\n`);
+      }
+      await waitForContent(page, 'LINE_09');
+
+      // Shrink to 40 cols — lines wrap (20 physical rows for 10 logical lines)
+      await page.evaluate(() => window.__termRef?.resize(40, 24));
+      await waitForRender(page);
+
+      // Simulate shell: move to bottom, erase from cursor to end of screen
+      // CSI <row>;1H = move to row, col 1
+      // CSI J = erase from cursor to end of display
+      const cursor = await getCursor(page);
+      await write(page, `\x1b[${cursor.row + 1};1H\x1b[JPROMPT> `);
+      await waitForRender(page);
+
+      // Expand back to 80 cols
+      await page.evaluate(() => window.__termRef?.resize(80, 24));
+      await waitForRender(page);
+
+      const rows = await readRows(page);
+      const allText = rows.join(' ');
+      // Lines above the cursor should survive (rejoined on expand)
+      expect(allText).toContain('LINE_00');
+      expect(allText).toContain('LINE_05');
+    });
+
+    test('round-trip 80→40→80 preserves multi-line output', async ({ page }) => {
+      // Write multiple lines of varying length
+      for (let i = 0; i < 10; i++) {
+        await write(page, `ROW_${String(i).padStart(2, '0')}_${'X'.repeat(70)}\r\n`);
+      }
+      await waitForContent(page, 'ROW_09');
+
+      // Shrink to 40 cols
+      await page.evaluate(() => window.__termRef?.resize(40, 24));
+      await waitForRender(page);
+
+      // Expand back to 80 cols
+      await page.evaluate(() => window.__termRef?.resize(80, 24));
+      await waitForRender(page);
+
+      // All rows should still be findable
+      const rows = await readRows(page);
+      const allText = rows.join(' ');
+      for (let i = 0; i < 10; i++) {
+        expect(allText).toContain(`ROW_${String(i).padStart(2, '0')}`);
+      }
+    });
+
+    test('scrollback + viewport round-trip reflow', async ({ page }) => {
+      // Write enough to push content into scrollback (>24 rows)
+      for (let i = 0; i < 40; i++) {
+        await write(page, `SB_${String(i).padStart(2, '0')}_${'Z'.repeat(75)}\r\n`);
+      }
+      await waitForContent(page, 'SB_39');
+
+      // Shrink to 40 cols — all 80-char lines wrap, scrollback grows
+      await page.evaluate(() => window.__termRef?.resize(40, 24));
+      await waitForRender(page);
+
+      // Expand back to 80 cols — should unwrap and recover
+      await page.evaluate(() => window.__termRef?.resize(80, 24));
+      await waitForRender(page);
+
+      // Recent rows should be visible and intact
+      const rows = await readRows(page);
+      const allText = rows.join(' ');
+      expect(allText).toContain('SB_39');
+      expect(allText).toContain('SB_38');
+    });
+
+    test('alt-screen resize preserves normal buffer', async ({ page }) => {
+      // Write content in normal buffer
+      await write(page, 'NORMAL_CONTENT_HERE\r\n');
+      await waitForContent(page, 'NORMAL_CONTENT');
+
+      // Enter alt screen
+      await write(page, '\x1b[?1049h');
+      await waitForRender(page);
+
+      // Resize while in alt screen
+      await page.evaluate(() => window.__termRef?.resize(40, 10));
+      await waitForRender(page);
+      await page.evaluate(() => window.__termRef?.resize(80, 24));
+      await waitForRender(page);
+
+      // Exit alt screen — normal buffer should still have content
+      await write(page, '\x1b[?1049l');
+      const rows = await waitForContent(page, 'NORMAL_CONTENT');
+      expect(rows.some(r => r.includes('NORMAL_CONTENT_HERE'))).toBe(true);
+    });
+  });
 });

--- a/packages/web/src/__tests__/web-terminal.test.ts
+++ b/packages/web/src/__tests__/web-terminal.test.ts
@@ -765,9 +765,14 @@ describe("WebTerminal", () => {
       (term as unknown as Record<string, (n: number) => void>).scrollViewport(2);
       expect((term as unknown as Record<string, number>).viewportOffset).toBe(2);
 
-      // Resize — scroll position should be preserved exactly
+      // Resize — with reflow (cols changed 80->40), scrollback is
+      // recalculated. Growing from 3 to 5 rows absorbs scrollback
+      // lines into the screen, so viewportOffset is clamped to the
+      // new (smaller) scrollback length.
       term.resize(40, 5);
-      expect((term as unknown as Record<string, number>).viewportOffset).toBe(2);
+      // 6 total rows (3 scrollback + 3 screen) -> 5 screen + 1 scrollback,
+      // so max viewportOffset is 1 (clamped from 2).
+      expect((term as unknown as Record<string, number>).viewportOffset).toBe(1);
 
       term.dispose();
     });

--- a/packages/web/src/parser-worker.ts
+++ b/packages/web/src/parser-worker.ts
@@ -42,6 +42,12 @@ interface ResizeMessage {
   scrollback: number;
   sharedBuffer?: SharedArrayBuffer;
   sharedAltBuffer?: SharedArrayBuffer;
+  /** Cursor position after reflow (so parser continues at the right spot). */
+  cursorRow?: number;
+  cursorCol?: number;
+  /** Reflowed grid data for non-SAB mode (so worker grid matches main thread). */
+  reflowedCellData?: ArrayBuffer;
+  reflowedWrapFlags?: ArrayBuffer;
 }
 
 interface DisposeMessage {
@@ -73,6 +79,8 @@ export interface FlushMessage {
   cellData?: ArrayBuffer;
   /** Dirty-row flags (Transferable). Only present in non-SAB mode. */
   dirtyRows?: ArrayBuffer;
+  /** Wrap flags per row (Transferable). Only present in non-SAB mode. */
+  wrapFlags?: ArrayBuffer;
   /** Circular buffer row offset. Only present in non-SAB mode. */
   rowOffset?: number;
 }
@@ -132,12 +140,14 @@ function buildFlush(bytesProcessed: number): FlushMessage {
   };
 
   if (!usingSAB) {
-    // Transfer cell data and dirty flags to the main thread.
+    // Transfer cell data, dirty flags, and wrap flags to the main thread.
     const grid = bufferSet.active.grid;
     const cellCopy = grid.data.slice().buffer;
     const dirtyCopy = grid.dirtyRows.slice().buffer;
+    const wrapCopy = grid.wrapFlags.slice().buffer;
     msg.cellData = cellCopy;
     msg.dirtyRows = dirtyCopy;
+    msg.wrapFlags = wrapCopy;
     msg.rowOffset = grid.rowOffsetData[0];
   }
 
@@ -176,6 +186,7 @@ function handleMessage(msg: InboundMessage): void {
         const transferables: ArrayBuffer[] = [];
         if (flush.cellData) transferables.push(flush.cellData);
         if (flush.dirtyRows) transferables.push(flush.dirtyRows);
+        if (flush.wrapFlags) transferables.push(flush.wrapFlags);
         (self as unknown as DedicatedWorkerGlobalScope).postMessage(flush, transferables);
       }
       break;
@@ -189,12 +200,34 @@ function handleMessage(msg: InboundMessage): void {
         msg.sharedBuffer,
         msg.sharedAltBuffer,
       );
+      // Restore cursor position after reflow so the parser continues
+      // at the right spot — prevents shell SIGWINCH response from
+      // overwriting reflowed content at (0,0).
+      if (parser && bufferSet && msg.cursorRow != null && msg.cursorCol != null) {
+        parser.cursor.row = Math.max(0, Math.min(msg.cursorRow, msg.rows - 1));
+        parser.cursor.col = Math.max(0, Math.min(msg.cursorCol, msg.cols - 1));
+      }
+      // In non-SAB mode, seed the worker's grid with the main thread's
+      // reflowed data so subsequent flushes don't send blank content.
+      if (!usingSAB && bufferSet && msg.reflowedCellData && msg.reflowedWrapFlags) {
+        const grid = bufferSet.active.grid;
+        const cellView = new Uint32Array(msg.reflowedCellData);
+        if (cellView.length === grid.data.length) {
+          grid.data.set(cellView);
+        }
+        const wrapView = new Int32Array(msg.reflowedWrapFlags);
+        if (wrapView.length === grid.wrapFlags.length) {
+          grid.wrapFlags.set(wrapView);
+        }
+        grid.markAllDirty();
+      }
       // Send a full flush so the main thread gets initial state.
       const flush = buildFlush(0);
       if (!usingSAB) {
         const transferables: ArrayBuffer[] = [];
         if (flush.cellData) transferables.push(flush.cellData);
         if (flush.dirtyRows) transferables.push(flush.dirtyRows);
+        if (flush.wrapFlags) transferables.push(flush.wrapFlags);
         (self as unknown as DedicatedWorkerGlobalScope).postMessage(flush, transferables);
       } else {
         (self as unknown as DedicatedWorkerGlobalScope).postMessage(flush);

--- a/packages/web/src/web-terminal.ts
+++ b/packages/web/src/web-terminal.ts
@@ -13,8 +13,15 @@
  * RenderBridge, leaving the main thread free for DOM event handling only.
  */
 
-import type { CursorState, MouseEncoding, MouseProtocol, Theme } from "@next_term/core";
-import { BufferSet, CELL_SIZE, CellGrid, DEFAULT_THEME, VTParser } from "@next_term/core";
+import type { CursorState, MouseEncoding, MouseProtocol, RowData, Theme } from "@next_term/core";
+import {
+  BufferSet,
+  CELL_SIZE,
+  CellGrid,
+  DEFAULT_THEME,
+  reflowRows,
+  VTParser,
+} from "@next_term/core";
 import { AccessibilityManager } from "./accessibility.js";
 import type { ITerminalAddon } from "./addon.js";
 import { calculateFit } from "./fit.js";
@@ -642,6 +649,8 @@ export class WebTerminal {
     if (this.disposed) return;
     // Guard against bad values
     if (!Number.isFinite(cols) || !Number.isFinite(rows) || cols < 2 || rows < 1) return;
+    // No-op when dimensions haven't changed — avoids destroying wrap flags
+    if (cols === this.bufferSet.cols && rows === this.bufferSet.rows) return;
 
     // Clear the stale display grid (wrong dimensions), but preserve
     // viewportOffset — we'll clamp it to the new scrollback length below.
@@ -658,54 +667,150 @@ export class WebTerminal {
     const oldCursor = oldBufferSet.active.cursor;
     const oldRows = oldBufferSet.rows;
 
-    // Create new buffer set
-    this.bufferSet = new BufferSet(cols, rows, scrollback);
+    const isAlt = oldBufferSet.isAlternate;
+    const colsChanged = cols !== oldBufferSet.cols;
 
-    // Copy content from old grid to new grid.
-    // When rows shrink, keep the bottom portion (where the cursor is).
-    // When rows grow, content stays at the top.
-    const newGrid = this.bufferSet.active.grid;
-    const copyRows = Math.min(oldRows, rows);
+    if (colsChanged && !isAlt) {
+      // ---- REFLOW PATH ----
+      // 1. Collect all rows: scrollback + viewport
+      const allRows: RowData[] = [];
 
-    // Determine source start row: if cursor was below the new row count,
-    // shift content up so cursor remains visible.
-    let srcStartRow = 0;
-    if (oldCursor.row >= rows) {
-      srcStartRow = oldCursor.row - rows + 1;
-    }
-
-    // Transfer existing scrollback first, then push overflow rows.
-    this.bufferSet.scrollback = oldBufferSet.scrollback;
-
-    // Push overflow rows (above the viewport) into scrollback so the
-    // user can scroll up to see them (#162). Only for the normal buffer
-    // — alt screen doesn't have scrollback. Skip when scrollback is
-    // disabled (maxScrollback === 0) to avoid wasteful copying.
-    if (srcStartRow > 0 && !oldBufferSet.isAlternate && scrollback > 0) {
-      const rowSize = oldGrid.cols * CELL_SIZE;
-      for (let r = 0; r < srcStartRow; r++) {
-        const buf = this.bufferSet.borrowRowBuffer(rowSize);
-        oldGrid.copyRowInto(r, buf);
-        this.bufferSet.pushScrollback(buf);
+      // Scrollback rows
+      for (let i = 0; i < oldBufferSet.scrollback.length; i++) {
+        allRows.push({
+          cells: oldBufferSet.scrollback[i],
+          wrapped: oldBufferSet.scrollbackWrap[i] ?? false,
+        });
       }
+
+      // Viewport rows
+      for (let r = 0; r < oldRows; r++) {
+        allRows.push({
+          cells: oldGrid.copyRow(r),
+          wrapped: oldGrid.isWrapped(r),
+        });
+      }
+
+      // 2. Compute cursor absolute position
+      const cursorAbsRow = oldBufferSet.scrollback.length + oldCursor.row;
+
+      // 3. Run reflow
+      const { reflowed, newCursorRow, newCursorCol } = reflowRows(
+        allRows,
+        oldBufferSet.cols,
+        cols,
+        cursorAbsRow,
+        oldCursor.col,
+      );
+
+      // 4. Create new BufferSet
+      this.bufferSet = new BufferSet(cols, rows, scrollback);
+      const newGrid = this.bufferSet.active.grid;
+
+      // 5. Split reflowed rows into scrollback vs screen
+      const totalReflowed = reflowed.length;
+      // Keep cursor at the same screen-relative position when possible.
+      // If cursor is near the top (newCursorRow < rows), keep it at that
+      // row on screen (screenStart = 0 in most cases). If cursor is below
+      // the visible area, place it at the bottom row of the screen.
+      const desiredScreenRow = Math.min(newCursorRow, rows - 1);
+      const screenStart = Math.max(
+        0,
+        Math.min(newCursorRow - desiredScreenRow, totalReflowed - rows),
+      );
+
+      // Scrollback: everything before screenStart.
+      // Reflowed rows are already at newCols width with defaults filled.
+      for (let i = 0; i < screenStart; i++) {
+        this.bufferSet.pushScrollback(reflowed[i].cells, reflowed[i].wrapped);
+      }
+
+      // Screen rows
+      for (let r = 0; r < rows; r++) {
+        const srcIdx = screenStart + r;
+        if (srcIdx < totalReflowed) {
+          const row = reflowed[srcIdx];
+          newGrid.pasteRow(r, row.cells, row.wrapped);
+        }
+      }
+
+      // Set cursor row/col (path-specific calculation)
+      const newCursor = this.bufferSet.active.cursor;
+      newCursor.row = Math.max(0, Math.min(newCursorRow - screenStart, rows - 1));
+      newCursor.col = Math.min(newCursorCol, cols - 1);
+      newCursor.wrapPending = false;
+    } else {
+      // ---- EXISTING TRUNCATION PATH (for alt screen or same-cols resize) ----
+      // Create new buffer set
+      this.bufferSet = new BufferSet(cols, rows, scrollback);
+
+      // Copy content from old grid to new grid.
+      // When rows shrink, keep the bottom portion (where the cursor is).
+      // When rows grow, content stays at the top.
+      const newGrid = this.bufferSet.active.grid;
+      const copyRows = Math.min(oldRows, rows);
+
+      // Determine source start row: if cursor was below the new row count,
+      // shift content up so cursor remains visible.
+      let srcStartRow = 0;
+      if (oldCursor.row >= rows) {
+        srcStartRow = oldCursor.row - rows + 1;
+      }
+
+      // Transfer existing scrollback first, then push overflow rows.
+      this.bufferSet.scrollback = oldBufferSet.scrollback;
+      this.bufferSet.scrollbackWrap = oldBufferSet.scrollbackWrap;
+
+      // Push overflow rows (above the viewport) into scrollback so the
+      // user can scroll up to see them (#162). Only for the normal buffer
+      // — alt screen doesn't have scrollback. Skip when scrollback is
+      // disabled (maxScrollback === 0) to avoid wasteful copying.
+      if (srcStartRow > 0 && !oldBufferSet.isAlternate && scrollback > 0) {
+        const rowSize = oldGrid.cols * CELL_SIZE;
+        for (let r = 0; r < srcStartRow; r++) {
+          const buf = this.bufferSet.borrowRowBuffer(rowSize);
+          oldGrid.copyRowInto(r, buf);
+          this.bufferSet.pushScrollback(buf, oldGrid.isWrapped(r));
+        }
+      }
+
+      for (let r = 0; r < copyRows; r++) {
+        const srcRow = srcStartRow + r;
+        if (srcRow >= oldRows) break;
+        const rowData = oldGrid.copyRow(srcRow);
+        newGrid.pasteRow(r, rowData, oldGrid.isWrapped(srcRow));
+      }
+
+      // When in alt-screen, also preserve the inactive normal buffer's
+      // grid content so it's not blank when the user exits alt mode.
+      if (isAlt) {
+        const oldNormalGrid = oldBufferSet.normal.grid;
+        const newNormalGrid = this.bufferSet.normal.grid;
+        const normalCopyRows = Math.min(oldBufferSet.rows, rows);
+        for (let r = 0; r < normalCopyRows; r++) {
+          const rowData = oldNormalGrid.copyRow(r);
+          newNormalGrid.pasteRow(r, rowData, oldNormalGrid.isWrapped(r));
+        }
+        // Preserve normal buffer's cursor
+        const oldNormalCursor = oldBufferSet.normal.cursor;
+        const newNormalCursor = this.bufferSet.normal.cursor;
+        newNormalCursor.row = Math.min(oldNormalCursor.row, rows - 1);
+        newNormalCursor.col = Math.min(oldNormalCursor.col, cols - 1);
+        newNormalCursor.visible = oldNormalCursor.visible;
+        newNormalCursor.style = oldNormalCursor.style;
+      }
+
+      // Adjust cursor position for the new dimensions
+      const newCursor = this.bufferSet.active.cursor;
+      newCursor.row = Math.max(0, Math.min(oldCursor.row - srcStartRow, rows - 1));
+      newCursor.col = Math.min(oldCursor.col, cols - 1);
     }
 
-    for (let r = 0; r < copyRows; r++) {
-      const srcRow = srcStartRow + r;
-      if (srcRow >= oldRows) break;
-      const rowData = oldGrid.copyRow(srcRow);
-      newGrid.pasteRow(r, rowData);
-    }
+    // Common post-resize: preserve cursor appearance, clamp scroll, mark dirty.
+    const finalCursor = this.bufferSet.active.cursor;
+    finalCursor.visible = oldCursor.visible;
+    finalCursor.style = oldCursor.style;
 
-    // Adjust cursor position for the new dimensions
-    const newCursor = this.bufferSet.active.cursor;
-    newCursor.row = Math.max(0, Math.min(oldCursor.row - srcStartRow, rows - 1));
-    newCursor.col = Math.min(oldCursor.col, cols - 1);
-    newCursor.visible = oldCursor.visible;
-    newCursor.style = oldCursor.style;
-
-    // Preserve scroll position: clamp viewportOffset to the new scrollback size.
-    // If the user was scrolled back, keep them at the same (or nearest valid) position.
     if (wasScrolledBack) {
       const maxOffset = this.bufferSet.scrollback.length;
       this.viewportOffset = Math.min(this.viewportOffset, maxOffset);
@@ -716,19 +821,18 @@ export class WebTerminal {
       this.viewportOffset = 0;
     }
 
-    newGrid.markAllDirty();
-
+    this.bufferSet.active.grid.markAllDirty();
     if (this.workerBridge) {
       // Save adjusted cursor — the worker's resize flush will send
       // cursor (0,0) from its fresh BufferSet, overwriting ours.
-      this.pendingResizeCursor = { row: newCursor.row, col: newCursor.col };
+      this.pendingResizeCursor = { row: finalCursor.row, col: finalCursor.col };
       // Update the bridge's grid reference and notify the worker.
       this.workerBridge.updateGrid(
         this.bufferSet.normal.grid,
         this.bufferSet.alternate.grid,
         this.bufferSet.active.cursor,
       );
-      this.workerBridge.resize(cols, rows, scrollback);
+      this.workerBridge.resize(cols, rows, scrollback, finalCursor.row, finalCursor.col);
     } else {
       this.parser = new VTParser(this.bufferSet);
       this.parser.setTitleChangeCallback((title: string) => {
@@ -1080,13 +1184,17 @@ export class WebTerminal {
         this.displayGrid.clearRow(r);
       } else if (virtualLine < scrollback.length) {
         // From scrollback
-        this.displayGrid.pasteRow(r, scrollback[virtualLine]);
+        this.displayGrid.pasteRow(
+          r,
+          scrollback[virtualLine],
+          this.bufferSet.scrollbackWrap[virtualLine] ?? false,
+        );
       } else {
         // From live buffer
         const bufRow = virtualLine - scrollback.length;
         if (bufRow < rows) {
           const rowData = this.bufferSet.active.grid.copyRow(bufRow);
-          this.displayGrid.pasteRow(r, rowData);
+          this.displayGrid.pasteRow(r, rowData, this.bufferSet.active.grid.isWrapped(bufRow));
         } else {
           this.displayGrid.clearRow(r);
         }

--- a/packages/web/src/worker-bridge.ts
+++ b/packages/web/src/worker-bridge.ts
@@ -43,6 +43,8 @@ export class WorkerBridge {
   private paused = false;
   /** Buffered writes waiting to be sent while paused. */
   private writeQueue: Uint8Array[] = [];
+  /** Skip cell data in pending non-SAB flushes (main thread already has reflowed data). */
+  private skipFlushCellDataCount = 0;
 
   private disposed = false;
 
@@ -102,7 +104,13 @@ export class WorkerBridge {
   /**
    * Notify the worker that the terminal has been resized.
    */
-  resize(cols: number, rows: number, scrollback: number): void {
+  resize(
+    cols: number,
+    rows: number,
+    scrollback: number,
+    cursorRow?: number,
+    cursorCol?: number,
+  ): void {
     if (this.disposed || !this.worker) return;
 
     // Reset flow control on resize — old pending data is irrelevant.
@@ -110,13 +118,43 @@ export class WorkerBridge {
     this.paused = false;
     this.writeQueue.length = 0;
 
-    this.worker.postMessage({
+    // In non-SAB mode, seed the worker with the main thread's reflowed
+    // grid data so the worker's state matches. Also skip the immediate
+    // post-resize flush's cell data (it would be the seeded content
+    // echoed back — wasteful but harmless). Use a counter so rapid
+    // resizes each get their flush skipped.
+    const msg: {
+      type: "resize";
+      cols: number;
+      rows: number;
+      scrollback: number;
+      cursorRow?: number;
+      cursorCol?: number;
+      sharedBuffer?: SharedArrayBuffer;
+      sharedAltBuffer?: SharedArrayBuffer;
+      reflowedCellData?: ArrayBuffer;
+      reflowedWrapFlags?: ArrayBuffer;
+    } = {
       type: "resize",
       cols,
       rows,
       scrollback,
+      cursorRow,
+      cursorCol,
       ...this.getSharedBuffers(),
-    });
+    };
+    const transferables: ArrayBuffer[] = [];
+
+    if (!SAB_AVAILABLE) {
+      this.skipFlushCellDataCount++;
+      const cellCopy = this.grid.data.slice().buffer;
+      const wrapCopy = this.grid.wrapFlags.slice().buffer;
+      msg.reflowedCellData = cellCopy;
+      msg.reflowedWrapFlags = wrapCopy;
+      transferables.push(cellCopy, wrapCopy);
+    }
+
+    this.worker.postMessage(msg, transferables);
   }
 
   /**
@@ -238,7 +276,12 @@ export class WorkerBridge {
     // In non-SAB mode, apply transferred cell data to the correct
     // main-thread grid. The worker always sends the active buffer's data;
     // select the target grid based on isAlternate.
-    if (msg.cellData && msg.dirtyRows) {
+    // Skip post-resize flushes — main thread already has reflowed data.
+    if (this.skipFlushCellDataCount > 0 && msg.cellData) {
+      this.skipFlushCellDataCount--;
+      // Skip cell data AND wrap flags — the worker echoes back the seeded
+      // content, so applying it would be a no-op. Flow control still updates.
+    } else if (msg.cellData && msg.dirtyRows) {
       const targetGrid = msg.isAlternate ? this.altGrid : this.grid;
       const cellView = new Uint32Array(msg.cellData);
       const dirtyView = new Int32Array(msg.dirtyRows);
@@ -270,6 +313,14 @@ export class WorkerBridge {
           const end = start + rowLen;
           targetGrid.data.set(cellView.subarray(start, end), start);
           targetGrid.markDirty(r);
+        }
+      }
+
+      // Sync wrap flags from the worker (non-SAB mode only).
+      if (msg.wrapFlags) {
+        const wrapView = new Int32Array(msg.wrapFlags);
+        if (wrapView.length === rows) {
+          targetGrid.wrapFlags.set(wrapView);
         }
       }
     }


### PR DESCRIPTION
## Summary

Implements text reflow so horizontal resize preserves all visible text instead of truncating it. When columns change, soft-wrapped lines are joined into logical lines and re-split at the new width, matching native terminal behavior (macOS Terminal, iTerm2).

Closes #170

## Architecture

- **Wrap flag tracking**: `wrapFlags: Int32Array` in CellGrid SAB layout (physical-row indexed, auto-rotates with circular buffer). `scrollbackWrap: boolean[]` parallel to scrollback. Parser sets flags at all 4 auto-wrap locations.
- **Reflow algorithm**: Pure `reflowRows()` function in `reflow.ts` — WezTerm-style join-then-split with cursor tracking, wide-char boundary handling, `MAX_LOGICAL_LINE_LEN` (4096) and `MAX_OUTPUT_ROWS` (200K) safety caps.
- **Resize integration**: Reflow path when cols change on normal screen; truncation path preserved for alt-screen and row-only resize. Common cursor/scroll/dirty code extracted after branch.
- **Worker sync**: Cursor position sent to worker in resize message (prevents SIGWINCH overwrite at 0,0). Non-SAB mode seeds worker with reflowed grid data via Transferable ArrayBuffers. `skipFlushCellDataCount` (counter) skips echoed post-resize flushes.
- **extractText**: Joins wrapped rows without newlines for correct clipboard copy.
- **Alt-screen**: Preserves inactive normal buffer content during resize.

## Safety

- Cursor clamped in worker to prevent out-of-bounds writes
- No-op resize guard (`cols === oldCols && rows === oldRows`) prevents wrap flag destruction from ResizeObserver noise
- Atomics used for wrapFlags reads/writes in shared mode (consistent with dirtyRows/cursor)
- `pasteRow()` extended with optional `wrapped` param to prevent forgotten `setWrapped` calls

## Test plan

- [x] 25 unit tests for reflow algorithm (shrink, expand, round-trip, wide chars, cursor tracking, MAX_LOGICAL_LINE_LEN)
- [x] 10 unit tests for wrap flag infrastructure (CellGrid + BufferSet)
- [x] 7 Playwright E2E tests (shrink/expand, hard breaks, SIGWINCH simulation, erase-below, scrollback round-trip, alt-screen preservation)
- [x] All 1752 unit tests pass
- [x] All 35 Playwright integration tests pass
- [x] Benchmark: no throughput regression (hot path untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)