### PR TITLE
fix: inline RGB in cell words to preserve truecolor (#146)

### DIFF
--- a/packages/core/src/__tests__/buffer.test.ts
+++ b/packages/core/src/__tests__/buffer.test.ts
@@ -337,4 +337,33 @@ describe("BufferSet scrollbackWrap", () => {
     expect(bs.scrollbackWrap[1]).toBe(true);
     expect(bs.scrollbackWrap[2]).toBe(false);
   });
+
+  it("scrollUpWithHistory stores compact flag for non-RGB rows", () => {
+    const bs = new BufferSet(10, 3, 5);
+    // Write a plain row (no RGB) to row 0
+    bs.active.grid.setCell(0, 0, 0x41, 7, 0, 0);
+    bs.scrollUpWithHistory();
+    expect(bs.scrollback.length).toBe(1);
+    expect(bs.scrollbackCompact[0]).toBe(true);
+    expect(bs.scrollback[0].length).toBe(10 * 2); // compact: 2 words/cell
+  });
+
+  it("scrollUpWithHistory stores full row for RGB rows", () => {
+    const bs = new BufferSet(10, 3, 5);
+    bs.active.grid.setCell(0, 0, 0x41, 0, 0, 0, true, false, 0xff0000);
+    bs.scrollUpWithHistory();
+    expect(bs.scrollback.length).toBe(1);
+    expect(bs.scrollbackCompact[0]).toBe(false);
+    expect(bs.scrollback[0].length).toBe(10 * 4); // full: CELL_SIZE words/cell
+  });
+
+  it("pushScrollback evicts compact flag alongside row data", () => {
+    const bs = new BufferSet(10, 3, 2);
+    bs.pushScrollback(new Uint32Array(20), false, true); // compact
+    bs.pushScrollback(new Uint32Array(40), false, false); // full
+    bs.pushScrollback(new Uint32Array(20), false, true); // evicts first
+    expect(bs.scrollbackCompact.length).toBe(2);
+    expect(bs.scrollbackCompact[0]).toBe(false);
+    expect(bs.scrollbackCompact[1]).toBe(true);
+  });
 });

--- a/packages/core/src/__tests__/cell-grid.test.ts
+++ b/packages/core/src/__tests__/cell-grid.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { CELL_SIZE, CellGrid } from "../cell-grid.js";
+import { CELL_SIZE, CellGrid, expandCompactRow } from "../cell-grid.js";
 
 describe("CellGrid", () => {
   it("creates a grid with correct dimensions", () => {
@@ -102,20 +102,75 @@ describe("CellGrid", () => {
     expect(grid.isBgRGB(2, 3)).toBe(true);
   });
 
-  it("copyRow does NOT preserve rgbColors table (known limitation #146)", () => {
-    // rgbColors is a shared per-grid column-indexed table, not per-row.
-    // Proper truecolor preservation requires cell format expansion.
+  it("copyRow preserves inline RGB values (#146)", () => {
     const grid = new CellGrid(10, 5);
-    grid.setCell(0, 3, 0x41, 0, 0, 0, true, true);
-    grid.rgbColors[3] = 0xff8040;
+    grid.setCell(0, 3, 0x41, 0, 0, 0, true, true, 0xff8040, 0x00cc55);
 
     const row = grid.copyRow(0);
-    grid.rgbColors[3] = 0x000000; // clear the shared table
+    grid.clearRow(2);
     grid.pasteRow(2, row);
 
-    // RGB flag is set but the actual color value is NOT restored
+    // RGB flags AND actual color values are preserved through copy/paste
     expect(grid.isFgRGB(2, 3)).toBe(true);
-    expect(grid.rgbColors[3]).toBe(0x000000); // NOT 0xff8040
+    expect(grid.isBgRGB(2, 3)).toBe(true);
+    expect(grid.getFgRGB(2, 3)).toBe(0xff8040);
+    expect(grid.getBgRGB(2, 3)).toBe(0x00cc55);
+  });
+
+  it("cross-row RGB: different rows preserve independent RGB values (#146)", () => {
+    const grid = new CellGrid(10, 5);
+    grid.setCell(0, 2, 0x41, 0, 0, 0, true, false, 0xff0000);
+    grid.setCell(1, 2, 0x42, 0, 0, 0, true, false, 0x00ff00);
+
+    // Each row stores its own RGB value inline — no cross-row clobbering
+    expect(grid.getFgRGB(0, 2)).toBe(0xff0000);
+    expect(grid.getFgRGB(1, 2)).toBe(0x00ff00);
+
+    // Copy row 0 to row 3, row 1 to row 4
+    const row0 = grid.copyRow(0);
+    const row1 = grid.copyRow(1);
+    grid.pasteRow(3, row0);
+    grid.pasteRow(4, row1);
+
+    // Both rows preserve their own RGB values
+    expect(grid.getFgRGB(3, 2)).toBe(0xff0000);
+    expect(grid.getFgRGB(4, 2)).toBe(0x00ff00);
+  });
+
+  it("copyRowCompact returns 2 words/cell for non-RGB rows", () => {
+    const grid = new CellGrid(10, 5);
+    grid.setCell(0, 0, 0x41, 7, 0, 0);
+    grid.setCell(0, 1, 0x42, 1, 2, 0);
+    const compact = grid.copyRowCompact(0);
+    // 10 cols × 2 words/cell = 20 words
+    expect(compact.length).toBe(10 * 2);
+    expect(compact[0] & 0x1fffff).toBe(0x41);
+    expect(compact[2] & 0x1fffff).toBe(0x42);
+  });
+
+  it("copyRowCompact returns 4 words/cell for RGB rows", () => {
+    const grid = new CellGrid(10, 5);
+    grid.setCell(0, 3, 0x41, 0, 0, 0, true, false, 0xff0000);
+    const full = grid.copyRowCompact(0);
+    expect(full.length).toBe(10 * CELL_SIZE);
+    // RGB value at word 2
+    expect(full[3 * CELL_SIZE + 2]).toBe(0xff0000);
+  });
+
+  it("compact round-trip through expandCompactRow preserves cell data", () => {
+    const grid = new CellGrid(10, 5);
+    grid.setCell(0, 0, 0x41, 3, 5, 0x01); // 'A', fg=3, bg=5, bold
+    grid.setCell(0, 9, 0x5a, 7, 0, 0); // 'Z' at last col
+    const compact = grid.copyRowCompact(0);
+    expect(compact.length).toBe(10 * 2); // non-RGB → compact
+    const expanded = expandCompactRow(compact, 10);
+    expect(expanded.length).toBe(10 * CELL_SIZE);
+    grid.pasteRow(2, expanded);
+    expect(grid.getCodepoint(2, 0)).toBe(0x41);
+    expect(grid.getFgIndex(2, 0)).toBe(3);
+    expect(grid.getBgIndex(2, 0)).toBe(5);
+    expect(grid.isBold(2, 0)).toBe(true);
+    expect(grid.getCodepoint(2, 9)).toBe(0x5a);
   });
 
   it("reports whether SharedArrayBuffer is used", () => {

--- a/packages/core/src/__tests__/cell-grid.test.ts
+++ b/packages/core/src/__tests__/cell-grid.test.ts
@@ -173,6 +173,23 @@ describe("CellGrid", () => {
     expect(grid.getCodepoint(2, 9)).toBe(0x5a);
   });
 
+  it("pasteCompactRow expands inline without allocation", () => {
+    const grid = new CellGrid(10, 5);
+    grid.setCell(0, 0, 0x41, 3, 5, 0x01);
+    grid.setCell(0, 9, 0x5a, 7, 0, 0);
+    const compact = grid.copyRowCompact(0);
+    expect(compact.length).toBe(10 * 2);
+    grid.pasteCompactRow(2, compact);
+    expect(grid.getCodepoint(2, 0)).toBe(0x41);
+    expect(grid.getFgIndex(2, 0)).toBe(3);
+    expect(grid.getBgIndex(2, 0)).toBe(5);
+    expect(grid.isBold(2, 0)).toBe(true);
+    expect(grid.getCodepoint(2, 9)).toBe(0x5a);
+    // RGB words should be zeroed
+    expect(grid.getFgRGB(2, 0)).toBe(0);
+    expect(grid.getBgRGB(2, 0)).toBe(0);
+  });
+
   it("reports whether SharedArrayBuffer is used", () => {
     const grid = new CellGrid(10, 5);
     // In Node/vitest SAB may or may not be available

--- a/packages/core/src/__tests__/integration.test.ts
+++ b/packages/core/src/__tests__/integration.test.ts
@@ -66,9 +66,9 @@ describe("24-bit RGB foreground", () => {
 
     expect(grid.getCodepoint(0, 0)).toBe(0x52); // 'R'
     expect(grid.isFgRGB(0, 0)).toBe(true);
-    // rgbColors[col] holds packed RGB for foreground
+    // Inline word 2 holds packed RGB for foreground
     const expectedRGB = (100 << 16) | (200 << 8) | 50;
-    expect(grid.rgbColors[0]).toBe(expectedRGB);
+    expect(grid.getFgRGB(0, 0)).toBe(expectedRGB);
   });
 });
 
@@ -111,7 +111,7 @@ describe("RGB background", () => {
     expect(grid.getCodepoint(0, 0)).toBe(0x44); // 'D'
     expect(grid.isBgRGB(0, 0)).toBe(true);
     const expectedRGB = (10 << 16) | (20 << 8) | 30;
-    expect(grid.rgbColors[256 + 0]).toBe(expectedRGB);
+    expect(grid.getBgRGB(0, 0)).toBe(expectedRGB);
   });
 });
 

--- a/packages/core/src/__tests__/integration.test.ts
+++ b/packages/core/src/__tests__/integration.test.ts
@@ -221,3 +221,41 @@ function readRowText(
   }
   return s;
 }
+
+// ---------------------------------------------------------------------------
+// ICH/DCH preserve inline RGB (#146)
+// ---------------------------------------------------------------------------
+describe("ICH/DCH preserve inline RGB", () => {
+  it("ICH shifts RGB cells right", () => {
+    const { parser, grid } = setup(10, 3);
+    // Write "AB" with RGB fg on 'B' at col 1
+    write(parser, "A\x1b[38;2;255;0;0mB\x1b[0m");
+    expect(grid.isFgRGB(0, 1)).toBe(true);
+    expect(grid.getFgRGB(0, 1)).toBe(0xff0000);
+
+    // Move cursor to col 0, insert 1 char (ICH)
+    write(parser, "\x1b[1G\x1b[1@");
+
+    // 'A' shifted to col 1, 'B' (with RGB) shifted to col 2
+    expect(grid.getCodepoint(0, 1)).toBe(0x41); // 'A'
+    expect(grid.getCodepoint(0, 2)).toBe(0x42); // 'B'
+    expect(grid.isFgRGB(0, 2)).toBe(true);
+    expect(grid.getFgRGB(0, 2)).toBe(0xff0000);
+  });
+
+  it("DCH shifts RGB cells left", () => {
+    const { parser, grid } = setup(10, 3);
+    // Write " B" — space at col 0, RGB 'B' at col 1
+    write(parser, " \x1b[38;2;0;255;0mB\x1b[0m");
+    expect(grid.isFgRGB(0, 1)).toBe(true);
+    expect(grid.getFgRGB(0, 1)).toBe(0x00ff00);
+
+    // Move cursor to col 0, delete 1 char (DCH)
+    write(parser, "\x1b[1G\x1b[1P");
+
+    // 'B' (with RGB) shifted to col 0
+    expect(grid.getCodepoint(0, 0)).toBe(0x42); // 'B'
+    expect(grid.isFgRGB(0, 0)).toBe(true);
+    expect(grid.getFgRGB(0, 0)).toBe(0x00ff00);
+  });
+});

--- a/packages/core/src/__tests__/integration.test.ts
+++ b/packages/core/src/__tests__/integration.test.ts
@@ -259,3 +259,23 @@ describe("ICH/DCH preserve inline RGB", () => {
     expect(grid.getFgRGB(0, 0)).toBe(0x00ff00);
   });
 });
+
+// ---------------------------------------------------------------------------
+// RGB black (0x000000) must not be dropped
+// ---------------------------------------------------------------------------
+describe("RGB black (0x000000)", () => {
+  it("fg RGB black is written and preserved, not stale", () => {
+    const { parser, grid } = setup(10, 3);
+    // Write a red cell, then overwrite same position with RGB black
+    write(parser, "\x1b[38;2;255;0;0mR\x1b[1G\x1b[38;2;0;0;0mB");
+    expect(grid.isFgRGB(0, 0)).toBe(true);
+    expect(grid.getFgRGB(0, 0)).toBe(0x000000);
+  });
+
+  it("bg RGB black is written and preserved", () => {
+    const { parser, grid } = setup(10, 3);
+    write(parser, "\x1b[48;2;0;0;0mX\x1b[0m");
+    expect(grid.isBgRGB(0, 0)).toBe(true);
+    expect(grid.getBgRGB(0, 0)).toBe(0x000000);
+  });
+});

--- a/packages/core/src/__tests__/sgr-compat.test.ts
+++ b/packages/core/src/__tests__/sgr-compat.test.ts
@@ -228,20 +228,20 @@ describe("SGR Compatibility Tests (ported from xterm.js / ghostty)", () => {
       expect(grid().isFgRGB(0, 0)).toBe(true);
       // The packed RGB value: (255 << 16) | (0 << 8) | 0 = 0xFF0000
       // The fg index field stores the low byte of fgRGB
-      // Full RGB is stored in rgbColors
-      expect(grid().rgbColors[0]).toBe(0xff0000);
+      // Full RGB is stored inline in cell word 2
+      expect(grid().getFgRGB(0, 0)).toBe(0xff0000);
     });
 
     it("48;2;0;255;0 sets bg to green RGB", () => {
       writeCharWithSGR("\x1b[48;2;0;255;0m");
       expect(grid().isBgRGB(0, 0)).toBe(true);
-      expect(grid().rgbColors[256 + 0]).toBe(0x00ff00);
+      expect(grid().getBgRGB(0, 0)).toBe(0x00ff00);
     });
 
     it("38;2;100;150;200 sets fg to custom RGB", () => {
       writeCharWithSGR("\x1b[38;2;100;150;200m");
       expect(grid().isFgRGB(0, 0)).toBe(true);
-      expect(grid().rgbColors[0]).toBe((100 << 16) | (150 << 8) | 200);
+      expect(grid().getFgRGB(0, 0)).toBe((100 << 16) | (150 << 8) | 200);
     });
   });
 

--- a/packages/core/src/buffer.ts
+++ b/packages/core/src/buffer.ts
@@ -112,6 +112,8 @@ export class BufferSet {
   scrollback: Uint32Array[];
   /** Per-line wrap flag for scrollback (parallel to scrollback[]). */
   scrollbackWrap: boolean[];
+  /** True if the corresponding scrollback row uses compact (2 word/cell) format. */
+  scrollbackCompact: boolean[];
   readonly maxScrollback: number;
 
   constructor(
@@ -130,6 +132,7 @@ export class BufferSet {
     this.active = this.normal;
     this.scrollback = [];
     this.scrollbackWrap = [];
+    this.scrollbackCompact = [];
     this.maxScrollback = maxScrollback;
   }
 
@@ -169,12 +172,14 @@ export class BufferSet {
    * returns scrollback[0] which the caller fills before calling this.
    * Reversing the order would evict the buffer before it's appended.
    */
-  pushScrollback(line: Uint32Array, wrapped = false): void {
+  pushScrollback(line: Uint32Array, wrapped = false, compact = false): void {
     this.scrollback.push(line);
     this.scrollbackWrap.push(wrapped);
+    this.scrollbackCompact.push(compact);
     if (this.scrollback.length > this.maxScrollback) {
       this.scrollback.shift();
       this.scrollbackWrap.shift();
+      this.scrollbackCompact.shift();
     }
   }
 
@@ -196,11 +201,21 @@ export class BufferSet {
   scrollUpWithHistory(): void {
     if (this.maxScrollback > 0 && this.active === this.normal && this.active.scrollTop === 0) {
       const grid = this.active.grid;
-      const rowSize = grid.cols * CELL_SIZE;
+      const hasRgb = grid.rowHasRgb(0);
+      const rowSize = hasRgb ? grid.cols * CELL_SIZE : grid.cols * 2;
       const dest = this.borrowRowBuffer(rowSize);
-      grid.copyRowInto(0, dest);
+      if (hasRgb) {
+        grid.copyRowInto(0, dest);
+      } else {
+        // Compact: copy only words 0,1 per cell
+        const start = grid.rowStart(0);
+        for (let c = 0; c < grid.cols; c++) {
+          dest[c * 2] = grid.data[start + c * CELL_SIZE];
+          dest[c * 2 + 1] = grid.data[start + c * CELL_SIZE + 1];
+        }
+      }
       const wasWrapped = grid.isWrapped(0);
-      this.pushScrollback(dest, wasWrapped);
+      this.pushScrollback(dest, wasWrapped, !hasRgb);
     }
     this.active.scrollUp();
   }

--- a/packages/core/src/buffer.ts
+++ b/packages/core/src/buffer.ts
@@ -190,7 +190,7 @@ export class BufferSet {
   borrowRowBuffer(size: number): Uint32Array {
     if (this.scrollback.length >= this.maxScrollback && this.maxScrollback > 0) {
       const existing = this.scrollback[0];
-      if (existing && existing.length >= size) {
+      if (existing && existing.length === size) {
         return existing;
       }
     }

--- a/packages/core/src/cell-grid.ts
+++ b/packages/core/src/cell-grid.ts
@@ -3,12 +3,14 @@ const SAB_AVAILABLE =
   typeof SharedArrayBuffer !== "undefined" &&
   (typeof crossOriginIsolated !== "undefined" ? crossOriginIsolated : true);
 
-// Cell packing: 2 x Uint32 per cell
+// Cell packing: 4 x Uint32 per cell
 // Word 0: [0-20] codepoint, [21] fg-is-rgb, [22] bg-is-rgb, [23-30] fg-index, [31] dirty
 // Word 1: [0-7] bg-index, [8] bold, [9] italic, [10] underline, [11] strikethrough,
 //         [12-13] underline-style, [14] inverse, [15] wide, [16-31] reserved
+// Word 2: fg RGB (24-bit packed, meaningful when fg-is-rgb flag is set)
+// Word 3: bg RGB (24-bit packed, meaningful when bg-is-rgb flag is set)
 
-export const CELL_SIZE = 2; // 2 x uint32 per cell
+export const CELL_SIZE = 4; // 4 x uint32 per cell
 
 /** Default blank cell word0: space (0x20) + default fg index 7. */
 export const DEFAULT_CELL_W0 = 0x20 | (7 << 23);
@@ -25,7 +27,6 @@ export class CellGrid {
   readonly rows: number;
   readonly data: Uint32Array;
   readonly dirtyRows: Int32Array;
-  readonly rgbColors: Uint32Array;
   private readonly buffer: SharedArrayBuffer | ArrayBuffer;
   readonly isShared: boolean;
   private readonly _templateRow: Uint32Array;
@@ -52,7 +53,6 @@ export class CellGrid {
 
     const cellBytes = cols * rows * CELL_SIZE * 4;
     const dirtyBytes = rows * 4; // Int32Array: 4 bytes per element
-    const rgbBytes = 512 * 4;
     const cursorBytes = 4 * 4; // 4 x Int32: row, col, visible, style
     const offsetBytes = 1 * 4; // 1 x Int32: row offset for circular buffer
     const wrapBytes = rows * 4; // Int32Array: 1 per row for wrap flags
@@ -63,7 +63,7 @@ export class CellGrid {
       this.buffer = existingBuffer;
       this.isShared = true;
     } else {
-      const totalBytes = cellBytes + dirtyBytes + rgbBytes + cursorBytes + offsetBytes + wrapBytes;
+      const totalBytes = cellBytes + dirtyBytes + cursorBytes + offsetBytes + wrapBytes;
       const BufferType = SAB_AVAILABLE ? SharedArrayBuffer : ArrayBuffer;
       this.buffer = new BufferType(totalBytes);
       this.isShared = SAB_AVAILABLE;
@@ -71,16 +71,11 @@ export class CellGrid {
 
     this.data = new Uint32Array(this.buffer, 0, cols * rows * CELL_SIZE);
     this.dirtyRows = new Int32Array(this.buffer, cellBytes, rows);
-    this.rgbColors = new Uint32Array(this.buffer, cellBytes + dirtyBytes, 512);
-    this.cursorData = new Int32Array(this.buffer, cellBytes + dirtyBytes + rgbBytes, 4);
-    this.rowOffsetData = new Int32Array(
-      this.buffer,
-      cellBytes + dirtyBytes + rgbBytes + cursorBytes,
-      1,
-    );
+    this.cursorData = new Int32Array(this.buffer, cellBytes + dirtyBytes, 4);
+    this.rowOffsetData = new Int32Array(this.buffer, cellBytes + dirtyBytes + cursorBytes, 1);
     this.wrapFlags = new Int32Array(
       this.buffer,
-      cellBytes + dirtyBytes + rgbBytes + cursorBytes + offsetBytes,
+      cellBytes + dirtyBytes + cursorBytes + offsetBytes,
       rows,
     );
 
@@ -195,6 +190,14 @@ export class CellGrid {
     return col > 0 && this.getCodepoint(row, col) === 0 && this.isWide(row, col - 1);
   }
 
+  getFgRGB(row: number, col: number): number {
+    return this.data[this.rowStart(row) + col * CELL_SIZE + 2];
+  }
+
+  getBgRGB(row: number, col: number): number {
+    return this.data[this.rowStart(row) + col * CELL_SIZE + 3];
+  }
+
   setCell(
     row: number,
     col: number,
@@ -204,6 +207,8 @@ export class CellGrid {
     attrs: number,
     fgIsRGB = false,
     bgIsRGB = false,
+    fgRGB = 0,
+    bgRGB = 0,
   ): void {
     const idx = this.rowStart(row) + col * CELL_SIZE;
     this.data[idx] =
@@ -212,6 +217,8 @@ export class CellGrid {
       (bgIsRGB ? 1 << 22 : 0) |
       ((fgIndex & 0xff) << 23);
     this.data[idx + 1] = (bgIndex & 0xff) | ((attrs & 0xff) << 8);
+    this.data[idx + 2] = fgRGB;
+    this.data[idx + 3] = bgRGB;
     this.markDirty(row);
   }
 
@@ -275,6 +282,33 @@ export class CellGrid {
     const start = this.rowStart(row);
     const len = this.cols * CELL_SIZE;
     for (let i = 0; i < len; i++) dest[i] = this.data[start + i];
+  }
+
+  /** True if any cell in a logical row has fg-is-rgb or bg-is-rgb flags. */
+  rowHasRgb(row: number): boolean {
+    const start = this.rowStart(row);
+    for (let c = 0; c < this.cols; c++) {
+      if (this.data[start + c * CELL_SIZE] & ((1 << 21) | (1 << 22))) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Copy a row in compact format (2 words/cell) when no RGB flags are set,
+   * or full format (4 words/cell) when RGB is present. This halves scrollback
+   * memory for the common non-truecolor case.
+   */
+  copyRowCompact(row: number): Uint32Array {
+    const start = this.rowStart(row);
+    if (this.rowHasRgb(row)) {
+      return new Uint32Array(this.data.slice(start, start + this.cols * CELL_SIZE));
+    }
+    const compact = new Uint32Array(this.cols * 2);
+    for (let c = 0; c < this.cols; c++) {
+      compact[c * 2] = this.data[start + c * CELL_SIZE];
+      compact[c * 2 + 1] = this.data[start + c * CELL_SIZE + 1];
+    }
+    return compact;
   }
 
   /** Overwrite a logical row from a previously copied Uint32Array. */
@@ -357,6 +391,30 @@ export class CellGrid {
   getBuffer(): SharedArrayBuffer | ArrayBuffer {
     return this.buffer;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Compact row expansion
+// ---------------------------------------------------------------------------
+
+/**
+ * Expand a compact (2 words/cell) scrollback row to full (CELL_SIZE words/cell).
+ * Fills words 2,3 with 0 (no RGB). Pads short rows with default cells.
+ */
+export function expandCompactRow(compact: Uint32Array, cols: number): Uint32Array {
+  const full = new Uint32Array(cols * CELL_SIZE);
+  const srcCols = compact.length >>> 1; // compact.length / 2
+  const copyCols = Math.min(srcCols, cols);
+  for (let c = 0; c < copyCols; c++) {
+    full[c * CELL_SIZE] = compact[c * 2];
+    full[c * CELL_SIZE + 1] = compact[c * 2 + 1];
+    // words 2,3 default to 0 (no RGB)
+  }
+  for (let c = copyCols; c < cols; c++) {
+    full[c * CELL_SIZE] = DEFAULT_CELL_W0;
+    full[c * CELL_SIZE + 1] = DEFAULT_CELL_W1;
+  }
+  return full;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/cell-grid.ts
+++ b/packages/core/src/cell-grid.ts
@@ -311,6 +311,32 @@ export class CellGrid {
     return compact;
   }
 
+  /**
+   * Paste a compact (2 words/cell) row directly into the grid, expanding
+   * inline without allocating. Words 2,3 are zeroed (no RGB).
+   */
+  pasteCompactRow(row: number, src: Uint32Array, wrapped?: boolean): void {
+    const start = this.rowStart(row);
+    const srcCols = src.length >>> 1;
+    const pasteCols = Math.min(srcCols, this.cols);
+    for (let c = 0; c < pasteCols; c++) {
+      this.data[start + c * CELL_SIZE] = src[c * 2];
+      this.data[start + c * CELL_SIZE + 1] = src[c * 2 + 1];
+      this.data[start + c * CELL_SIZE + 2] = 0;
+      this.data[start + c * CELL_SIZE + 3] = 0;
+    }
+    for (let c = pasteCols; c < this.cols; c++) {
+      this.data[start + c * CELL_SIZE] = DEFAULT_CELL_W0;
+      this.data[start + c * CELL_SIZE + 1] = DEFAULT_CELL_W1;
+      this.data[start + c * CELL_SIZE + 2] = 0;
+      this.data[start + c * CELL_SIZE + 3] = 0;
+    }
+    if (wrapped !== undefined) {
+      this.setWrapped(row, wrapped);
+    }
+    this.markDirty(row);
+  }
+
   /** Overwrite a logical row from a previously copied Uint32Array. */
   pasteRow(row: number, src: Uint32Array, wrapped?: boolean): void {
     const start = this.rowStart(row);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ export {
   CellGrid,
   DEFAULT_CELL_W0,
   DEFAULT_CELL_W1,
+  expandCompactRow,
   extractText,
   modPositive,
   normalizeSelection,

--- a/packages/core/src/parser/index.ts
+++ b/packages/core/src/parser/index.ts
@@ -1922,13 +1922,15 @@ export class VTParser {
     const row = cursor.row;
     // Clamp n to remaining space
     n = Math.min(n, this.cols - cursor.col);
-    // Shift cells right using physical row offset
+    // Shift cells right using physical row offset (all 4 words per cell)
     const rowBase = this.grid.rowStart(row);
     for (let c = this.cols - 1; c >= cursor.col + n; c--) {
       const src = rowBase + (c - n) * CELL_SIZE;
       const dst = rowBase + c * CELL_SIZE;
       this.grid.data[dst] = this.grid.data[src];
       this.grid.data[dst + 1] = this.grid.data[src + 1];
+      this.grid.data[dst + 2] = this.grid.data[src + 2];
+      this.grid.data[dst + 3] = this.grid.data[src + 3];
     }
     // Clear inserted cells with default colors
     for (let i = 0; i < n; i++) {
@@ -1942,13 +1944,15 @@ export class VTParser {
     const row = cursor.row;
     // Clamp n to remaining space
     n = Math.min(n, this.cols - cursor.col);
-    // Shift cells left using physical row offset
+    // Shift cells left using physical row offset (all 4 words per cell)
     const rowBase = this.grid.rowStart(row);
     for (let c = cursor.col; c < this.cols - n; c++) {
       const src = rowBase + (c + n) * CELL_SIZE;
       const dst = rowBase + c * CELL_SIZE;
       this.grid.data[dst] = this.grid.data[src];
       this.grid.data[dst + 1] = this.grid.data[src + 1];
+      this.grid.data[dst + 2] = this.grid.data[src + 2];
+      this.grid.data[dst + 3] = this.grid.data[src + 3];
     }
     // Clear vacated cells at end with default colors
     for (let c = this.cols - n; c < this.cols; c++) {

--- a/packages/core/src/parser/index.ts
+++ b/packages/core/src/parser/index.ts
@@ -542,6 +542,9 @@ export class VTParser {
         const word1 =
           ((this.bgIsRGB ? this.bgRGB & 0xff : this.bgIndex) & 0xff) | ((this.attrs & 0xff) << 8);
         const word1Wide = word1 | (ATTR_WIDE << 8);
+        const word2 = this.fgIsRGB ? this.fgRGB : 0;
+        const word3 = this.bgIsRGB ? this.bgRGB : 0;
+        const hasRgb = word2 !== 0 || word3 !== 0;
 
         let cachedRow = cursor.row;
         let cachedRowStart = grid.rowStart(cachedRow);
@@ -627,8 +630,10 @@ export class VTParser {
             // Fill current cell with space, then wrap
             gridData[cellIdx] = 0x20 | word0Base;
             gridData[cellIdx + 1] = word1;
-            gridData[cellIdx + 2] = this.fgIsRGB ? this.fgRGB : 0;
-            gridData[cellIdx + 3] = this.bgIsRGB ? this.bgRGB : 0;
+            if (hasRgb) {
+              gridData[cellIdx + 2] = word2;
+              gridData[cellIdx + 3] = word3;
+            }
             grid.setWrapped(cachedRow, true);
             grid.markDirty(cachedRow);
             cursor.col = 0;
@@ -644,8 +649,10 @@ export class VTParser {
 
           gridData[cellIdx] = (cp & 0x1fffff) | word0Base;
           gridData[cellIdx + 1] = charWidth === 2 ? word1Wide : word1;
-          gridData[cellIdx + 2] = this.fgIsRGB ? this.fgRGB : 0;
-          gridData[cellIdx + 3] = this.bgIsRGB ? this.bgRGB : 0;
+          if (hasRgb) {
+            gridData[cellIdx + 2] = word2;
+            gridData[cellIdx + 3] = word3;
+          }
 
           if (charWidth === 2) {
             // Write spacer in next cell (right half of wide char)
@@ -654,8 +661,10 @@ export class VTParser {
               cellIdx += CELL_SIZE;
               gridData[cellIdx] = word0Base; // codepoint 0 = spacer
               gridData[cellIdx + 1] = word1;
-              gridData[cellIdx + 2] = this.fgIsRGB ? this.fgRGB : 0;
-              gridData[cellIdx + 3] = this.bgIsRGB ? this.bgRGB : 0;
+              if (hasRgb) {
+                gridData[cellIdx + 2] = word2;
+                gridData[cellIdx + 3] = word3;
+              }
             }
           }
 

--- a/packages/core/src/parser/index.ts
+++ b/packages/core/src/parser/index.ts
@@ -627,6 +627,8 @@ export class VTParser {
             // Fill current cell with space, then wrap
             gridData[cellIdx] = 0x20 | word0Base;
             gridData[cellIdx + 1] = word1;
+            gridData[cellIdx + 2] = this.fgIsRGB ? this.fgRGB : 0;
+            gridData[cellIdx + 3] = this.bgIsRGB ? this.bgRGB : 0;
             grid.setWrapped(cachedRow, true);
             grid.markDirty(cachedRow);
             cursor.col = 0;
@@ -642,9 +644,8 @@ export class VTParser {
 
           gridData[cellIdx] = (cp & 0x1fffff) | word0Base;
           gridData[cellIdx + 1] = charWidth === 2 ? word1Wide : word1;
-
-          if (this.fgIsRGB) grid.rgbColors[cursor.col] = this.fgRGB;
-          if (this.bgIsRGB) grid.rgbColors[256 + cursor.col] = this.bgRGB;
+          gridData[cellIdx + 2] = this.fgIsRGB ? this.fgRGB : 0;
+          gridData[cellIdx + 3] = this.bgIsRGB ? this.bgRGB : 0;
 
           if (charWidth === 2) {
             // Write spacer in next cell (right half of wide char)
@@ -653,6 +654,8 @@ export class VTParser {
               cellIdx += CELL_SIZE;
               gridData[cellIdx] = word0Base; // codepoint 0 = spacer
               gridData[cellIdx + 1] = word1;
+              gridData[cellIdx + 2] = this.fgIsRGB ? this.fgRGB : 0;
+              gridData[cellIdx + 3] = this.bgIsRGB ? this.bgRGB : 0;
             }
           }
 
@@ -875,6 +878,8 @@ export class VTParser {
         0x20 | (this.fgIsRGB ? 1 << 21 : 0) | (this.bgIsRGB ? 1 << 22 : 0) | ((fgVal & 0xff) << 23);
       grid.data[idx + 1] =
         ((this.bgIsRGB ? this.bgRGB & 0xff : this.bgIndex) & 0xff) | ((this.attrs & 0xff) << 8);
+      grid.data[idx + 2] = this.fgIsRGB ? this.fgRGB : 0;
+      grid.data[idx + 3] = this.bgIsRGB ? this.bgRGB : 0;
       grid.setWrapped(cursor.row, true);
       grid.markDirty(cursor.row);
 
@@ -897,15 +902,9 @@ export class VTParser {
     const attrsWithWide = charWidth === 2 ? this.attrs | ATTR_WIDE : this.attrs;
     grid.data[idx + 1] =
       ((this.bgIsRGB ? this.bgRGB & 0xff : this.bgIndex) & 0xff) | ((attrsWithWide & 0xff) << 8);
+    grid.data[idx + 2] = this.fgIsRGB ? this.fgRGB : 0;
+    grid.data[idx + 3] = this.bgIsRGB ? this.bgRGB : 0;
     grid.markDirty(cursor.row);
-
-    // Store full RGB values in the rgbColors lookup if using RGB
-    if (this.fgIsRGB) {
-      grid.rgbColors[cursor.col] = this.fgRGB;
-    }
-    if (this.bgIsRGB) {
-      grid.rgbColors[256 + cursor.col] = this.bgRGB;
-    }
 
     this.lastPrintedCodepoint = cp;
 
@@ -918,6 +917,8 @@ export class VTParser {
           (this.fgIsRGB ? 1 << 21 : 0) | (this.bgIsRGB ? 1 << 22 : 0) | ((fgVal & 0xff) << 23); // codepoint 0 = spacer
         grid.data[spacerIdx + 1] =
           ((this.bgIsRGB ? this.bgRGB & 0xff : this.bgIndex) & 0xff) | ((this.attrs & 0xff) << 8);
+        grid.data[spacerIdx + 2] = this.fgIsRGB ? this.fgRGB : 0;
+        grid.data[spacerIdx + 3] = this.bgIsRGB ? this.bgRGB : 0;
       }
     }
 
@@ -978,11 +979,20 @@ export class VTParser {
     if (buf.scrollTop === 0 && buf.scrollBottom === this.rows - 1) {
       const grid = buf.grid;
       if (this.bufferSet.maxScrollback > 0 && buf === this.bufferSet.normal) {
-        const rowSize = grid.cols * CELL_SIZE;
+        const hasRgb = grid.rowHasRgb(0);
+        const rowSize = hasRgb ? grid.cols * CELL_SIZE : grid.cols * 2;
         const dest = this.bufferSet.borrowRowBuffer(rowSize);
-        grid.copyRowInto(0, dest);
+        if (hasRgb) {
+          grid.copyRowInto(0, dest);
+        } else {
+          const start = grid.rowStart(0);
+          for (let c = 0; c < grid.cols; c++) {
+            dest[c * 2] = grid.data[start + c * CELL_SIZE];
+            dest[c * 2 + 1] = grid.data[start + c * CELL_SIZE + 1];
+          }
+        }
         const wasWrapped = grid.isWrapped(0);
-        this.bufferSet.pushScrollback(dest, wasWrapped);
+        this.bufferSet.pushScrollback(dest, wasWrapped, !hasRgb);
       }
       grid.rotateUp();
       grid.clearRowRaw(buf.scrollBottom);

--- a/packages/core/src/parser/index.ts
+++ b/packages/core/src/parser/index.ts
@@ -544,7 +544,7 @@ export class VTParser {
         const word1Wide = word1 | (ATTR_WIDE << 8);
         const word2 = this.fgIsRGB ? this.fgRGB : 0;
         const word3 = this.bgIsRGB ? this.bgRGB : 0;
-        const hasRgb = word2 !== 0 || word3 !== 0;
+        const hasRgb = this.fgIsRGB || this.bgIsRGB;
 
         let cachedRow = cursor.row;
         let cachedRowStart = grid.rowStart(cachedRow);

--- a/packages/native/src/__tests__/skia-renderer.test.ts
+++ b/packages/native/src/__tests__/skia-renderer.test.ts
@@ -532,9 +532,9 @@ describe("SkiaRenderer", () => {
       const renderer = createRenderer();
       const grid = new CellGrid(5, 1);
 
-      // fgIsRGB=true; rgbColors[col] holds the packed 24-bit value
-      grid.setCell(0, 0, 0x41, 0, 0, 0, true, false); // 'A', fgIsRGB=true
-      grid.rgbColors[0] = (255 << 16) | (128 << 8) | 0; // rgb(255,128,0)
+      // fgIsRGB=true; RGB stored inline in cell word 2
+      const fgRGB = (255 << 16) | (128 << 8) | 0; // rgb(255,128,0)
+      grid.setCell(0, 0, 0x41, 0, 0, 0, true, false, fgRGB);
 
       const cursor: CursorState = {
         row: 0,
@@ -555,9 +555,9 @@ describe("SkiaRenderer", () => {
       const renderer = createRenderer();
       const grid = new CellGrid(5, 1);
 
-      // bgIsRGB=true; rgbColors[256 + col] holds the packed 24-bit value
-      grid.setCell(0, 0, 0x41, 7, 0, 0, false, true); // 'A', bgIsRGB=true
-      grid.rgbColors[256 + 0] = (0 << 16) | (0 << 8) | 200; // rgb(0,0,200)
+      // bgIsRGB=true; RGB stored inline in cell word 3
+      const bgRGB = (0 << 16) | (0 << 8) | 200; // rgb(0,0,200)
+      grid.setCell(0, 0, 0x41, 7, 0, 0, false, true, 0, bgRGB);
 
       const cursor: CursorState = {
         row: 0,
@@ -580,8 +580,8 @@ describe("SkiaRenderer", () => {
 
       // fgIsRGB=true, attrs=0x40 (inverse).
       // After swap: bg = rgb(200,50,10), text = theme.background.
-      grid.setCell(0, 0, 0x43, 0, 0, 0x40, true, false); // 'C', fgIsRGB, inverse
-      grid.rgbColors[0] = (200 << 16) | (50 << 8) | 10; // rgb(200,50,10)
+      const fgRGB2 = (200 << 16) | (50 << 8) | 10; // rgb(200,50,10)
+      grid.setCell(0, 0, 0x43, 0, 0, 0x40, true, false, fgRGB2); // 'C', fgIsRGB, inverse
 
       const cursor: CursorState = {
         row: 0,
@@ -612,8 +612,8 @@ describe("SkiaRenderer", () => {
       // resolveColor(7, false) → theme.foreground
       // resolveColor(0, true)  → rgb(100,200,50) from rgbColors[256+col]
       // After swap: fg = rgb(100,200,50), bg = theme.foreground
-      grid.setCell(0, 0, 0x44, 7, 0, 0x40, false, true); // 'D', bgIsRGB, inverse
-      grid.rgbColors[256 + 0] = (100 << 16) | (200 << 8) | 50; // rgb(100,200,50)
+      const bgRGB2 = (100 << 16) | (200 << 8) | 50; // rgb(100,200,50)
+      grid.setCell(0, 0, 0x44, 7, 0, 0x40, false, true, 0, bgRGB2); // 'D', bgIsRGB, inverse
 
       const cursor: CursorState = {
         row: 0,

--- a/packages/native/src/renderer/SkiaRenderer.ts
+++ b/packages/native/src/renderer/SkiaRenderer.ts
@@ -155,8 +155,8 @@ export class SkiaRenderer {
         const fgIsRGB = grid.isFgRGB(row, col);
         const bgIsRGB = grid.isBgRGB(row, col);
 
-        let fg = this.resolveColor(fgIdx, fgIsRGB, grid, col, true);
-        let bg = this.resolveColor(bgIdx, bgIsRGB, grid, col, false);
+        let fg = this.resolveColor(fgIdx, fgIsRGB, grid.getFgRGB(row, col), true);
+        let bg = this.resolveColor(bgIdx, bgIsRGB, grid.getBgRGB(row, col), false);
 
         // Handle inverse attribute
         if (attrs & ATTR_INVERSE) {
@@ -327,16 +327,13 @@ export class SkiaRenderer {
   private resolveColor(
     colorIdx: number,
     isRGB: boolean,
-    grid: CellGrid,
-    col: number,
+    rgbValue: number,
     isForeground: boolean,
   ): string {
     if (isRGB) {
-      const offset = isForeground ? col : 256 + col;
-      const rgb = grid.rgbColors[offset];
-      const r = (rgb >> 16) & 0xff;
-      const g = (rgb >> 8) & 0xff;
-      const b = rgb & 0xff;
+      const r = (rgbValue >> 16) & 0xff;
+      const g = (rgbValue >> 8) & 0xff;
+      const b = rgbValue & 0xff;
       return `rgb(${r},${g},${b})`;
     }
 

--- a/packages/web/src/__tests__/integration.test.ts
+++ b/packages/web/src/__tests__/integration.test.ts
@@ -1,4 +1,4 @@
-import { CellGrid, DEFAULT_THEME } from "@next_term/core";
+import { DEFAULT_THEME } from "@next_term/core";
 import { describe, expect, it } from "vitest";
 import { build256Palette } from "../renderer.js";
 
@@ -83,16 +83,13 @@ describe("Color resolution", () => {
   function resolveCellColor(
     colorIdx: number,
     isRGB: boolean,
-    grid: CellGrid,
-    col: number,
+    rgbValue: number,
     isForeground: boolean,
   ): string {
     if (isRGB) {
-      const offset = isForeground ? col : 256 + col;
-      const rgb = grid.rgbColors[offset];
-      const r = (rgb >> 16) & 0xff;
-      const g = (rgb >> 8) & 0xff;
-      const b = rgb & 0xff;
+      const r = (rgbValue >> 16) & 0xff;
+      const g = (rgbValue >> 8) & 0xff;
+      const b = rgbValue & 0xff;
       return `rgb(${r},${g},${b})`;
     }
 
@@ -106,45 +103,39 @@ describe("Color resolution", () => {
     return isForeground ? DEFAULT_THEME.foreground : DEFAULT_THEME.background;
   }
 
-  const grid = new CellGrid(80, 24);
-
   it("fgIndex=7 resolves to theme.foreground", () => {
-    expect(resolveCellColor(7, false, grid, 0, true)).toBe(DEFAULT_THEME.foreground);
+    expect(resolveCellColor(7, false, 0, true)).toBe(DEFAULT_THEME.foreground);
   });
 
   it("bgIndex=0 resolves to theme.background", () => {
-    expect(resolveCellColor(0, false, grid, 0, false)).toBe(DEFAULT_THEME.background);
+    expect(resolveCellColor(0, false, 0, false)).toBe(DEFAULT_THEME.background);
   });
 
   it("fgIndex=1 resolves to palette[1] (red)", () => {
-    expect(resolveCellColor(1, false, grid, 0, true)).toBe(palette[1]);
-    expect(resolveCellColor(1, false, grid, 0, true)).toBe(DEFAULT_THEME.red);
+    expect(resolveCellColor(1, false, 0, true)).toBe(palette[1]);
+    expect(resolveCellColor(1, false, 0, true)).toBe(DEFAULT_THEME.red);
   });
 
   it("bgIndex=2 resolves to palette[2] (green)", () => {
-    expect(resolveCellColor(2, false, grid, 0, false)).toBe(palette[2]);
-    expect(resolveCellColor(2, false, grid, 0, false)).toBe(DEFAULT_THEME.green);
+    expect(resolveCellColor(2, false, 0, false)).toBe(palette[2]);
+    expect(resolveCellColor(2, false, 0, false)).toBe(DEFAULT_THEME.green);
   });
 
   it("fgIndex=8 resolves to palette[8] (brightBlack)", () => {
-    expect(resolveCellColor(8, false, grid, 0, true)).toBe(DEFAULT_THEME.brightBlack);
+    expect(resolveCellColor(8, false, 0, true)).toBe(DEFAULT_THEME.brightBlack);
   });
 
   it("256-color index resolves to correct palette entry", () => {
-    expect(resolveCellColor(123, false, grid, 0, true)).toBe(palette[123]);
+    expect(resolveCellColor(123, false, 0, true)).toBe(palette[123]);
   });
 
-  it("RGB foreground resolves from rgbColors", () => {
-    const testGrid = new CellGrid(80, 24);
+  it("RGB foreground resolves from inline cell data", () => {
     const packedRGB = (255 << 16) | (128 << 8) | 64;
-    testGrid.rgbColors[5] = packedRGB; // col=5, foreground
-    expect(resolveCellColor(0, true, testGrid, 5, true)).toBe("rgb(255,128,64)");
+    expect(resolveCellColor(0, true, packedRGB, true)).toBe("rgb(255,128,64)");
   });
 
-  it("RGB background resolves from rgbColors[256 + col]", () => {
-    const testGrid = new CellGrid(80, 24);
+  it("RGB background resolves from inline cell data", () => {
     const packedRGB = (10 << 16) | (20 << 8) | 30;
-    testGrid.rgbColors[256 + 3] = packedRGB; // col=3, background
-    expect(resolveCellColor(0, true, testGrid, 3, false)).toBe("rgb(10,20,30)");
+    expect(resolveCellColor(0, true, packedRGB, false)).toBe("rgb(10,20,30)");
   });
 });

--- a/packages/web/src/__tests__/parser-worker.test.ts
+++ b/packages/web/src/__tests__/parser-worker.test.ts
@@ -54,7 +54,7 @@ function lastFlush(): FlushMessage {
  * Read the codepoint stored at a logical cell position from a transferred
  * cellData ArrayBuffer.
  *
- * Cell layout (matches cell-grid.ts): 2 × uint32 per cell; the codepoint
+ * Cell layout (matches cell-grid.ts): 4 × uint32 per cell; the codepoint
  * occupies the low 21 bits of word 0.  The grid uses a circular row buffer
  * rotated by `rowOffset` (from the flush message; 0 on a freshly initialised
  * terminal).
@@ -67,7 +67,7 @@ function getCellCodepoint(
   rowOffset: number,
   rows: number,
 ): number {
-  const CELL_SIZE = 2;
+  const CELL_SIZE = 4;
   const physRow = (row + rowOffset) % rows;
   const uint32 = new Uint32Array(cellData);
   return uint32[(physRow * cols + col) * CELL_SIZE] & 0x1fffff;

--- a/packages/web/src/__tests__/renderer-rendering.test.ts
+++ b/packages/web/src/__tests__/renderer-rendering.test.ts
@@ -485,10 +485,9 @@ describe("Canvas2DRenderer — color resolution via render", () => {
 
   it("RGB foreground color uses rgb(r,g,b) string", () => {
     const { renderer, grid } = makeRenderer(10, 5);
-    // fgIsRGB=true; store RGB value in grid.rgbColors at offset=col=0
-    grid.setCell(0, 0, 0x43, 0, 0, 0, true, false); // fgIsRGB=true
-    // rgb(255, 128, 64) → packed as (255 << 16) | (128 << 8) | 64
-    grid.rgbColors[0] = (255 << 16) | (128 << 8) | 64;
+    // fgIsRGB=true; RGB value stored inline in cell word 2
+    const fgRGB = (255 << 16) | (128 << 8) | 64;
+    grid.setCell(0, 0, 0x43, 0, 0, 0, true, false, fgRGB);
     mockCtx.ops.length = 0;
     renderer.render();
 
@@ -521,10 +520,10 @@ describe("Canvas2DRenderer — color resolution via render", () => {
 
   it("RGB background color uses rgb(r,g,b) string for bg fillRect", () => {
     const { renderer, grid } = makeRenderer(10, 5);
-    // bgIsRGB=true: background is a true-color value stored at rgbColors[256+col]
+    // bgIsRGB=true: background is a true-color value stored inline in cell word 3
     // fg stays as default (index 7 → theme.foreground)
-    grid.setCell(0, 0, 0x43, 7, 0, 0, false, true); // codepoint 'C', fgIsRGB=false, bgIsRGB=true
-    grid.rgbColors[256 + 0] = (200 << 16) | (100 << 8) | 50; // rgb(200,100,50)
+    const bgRGB = (200 << 16) | (100 << 8) | 50; // rgb(200,100,50)
+    grid.setCell(0, 0, 0x43, 7, 0, 0, false, true, 0, bgRGB);
     mockCtx.ops.length = 0;
     renderer.render();
 
@@ -544,8 +543,8 @@ describe("Canvas2DRenderer — color resolution via render", () => {
     const { renderer, grid } = makeRenderer(10, 5);
     // fgIsRGB=false (fg=index 1, i.e. red palette), bgIsRGB=true, ATTR_INVERSE
     // After inversion: effective fg = rgb(200,100,50), effective bg = palette[1] (red)
-    grid.setCell(0, 0, 0x44, 1, 0, ATTR_INVERSE, false, true); // codepoint 'D', bg=RGB, ATTR_INVERSE
-    grid.rgbColors[256 + 0] = (200 << 16) | (100 << 8) | 50; // rgb(200,100,50) as bg
+    const bgRGB2 = (200 << 16) | (100 << 8) | 50; // rgb(200,100,50) as bg
+    grid.setCell(0, 0, 0x44, 1, 0, ATTR_INVERSE, false, true, 0, bgRGB2); // codepoint 'D', bg=RGB, ATTR_INVERSE
     mockCtx.ops.length = 0;
     renderer.render();
 
@@ -908,9 +907,9 @@ describe("Canvas2DRenderer — render loop", () => {
   let ctxSpy: { mockRestore(): void };
   // Manually-controlled RAF queue
   const rafCallbacks: FrameRequestCallback[] = [];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // biome-ignore lint/suspicious/noExplicitAny: vi.spyOn returns complex mock types
   let rafSpy: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // biome-ignore lint/suspicious/noExplicitAny: vi.spyOn returns complex mock types
   let cafSpy: any;
 
   function flushOneFrame() {

--- a/packages/web/src/__tests__/webgl-utils.test.ts
+++ b/packages/web/src/__tests__/webgl-utils.test.ts
@@ -1,6 +1,5 @@
 // @vitest-environment jsdom
 
-import { CellGrid } from "@next_term/core";
 import { describe, expect, it } from "vitest";
 import { type ColorFloat4, resolveColorFloat } from "../webgl-utils.js";
 
@@ -26,71 +25,52 @@ const THEME_BG: ColorFloat4 = [0.1, 0.1, 0.1, 1.0]; // ~#1a1a1a
 
 describe("resolveColorFloat", () => {
   it("returns theme foreground float for default fg (colorIdx=7, isForeground=true)", () => {
-    const grid = new CellGrid(10, 5);
     const palette = makePaletteFloat();
-
-    const result = resolveColorFloat(7, false, grid, 0, true, palette, THEME_FG, THEME_BG);
+    const result = resolveColorFloat(7, false, 0, true, palette, THEME_FG, THEME_BG);
     expect(result).toBe(THEME_FG);
   });
 
   it("returns theme background float for default bg (colorIdx=0, isForeground=false)", () => {
-    const grid = new CellGrid(10, 5);
     const palette = makePaletteFloat();
-
-    const result = resolveColorFloat(0, false, grid, 0, false, palette, THEME_FG, THEME_BG);
+    const result = resolveColorFloat(0, false, 0, false, palette, THEME_FG, THEME_BG);
     expect(result).toBe(THEME_BG);
   });
 
   it("returns palette color for indexed color (e.g., colorIdx=1)", () => {
-    const grid = new CellGrid(10, 5);
     const palette = makePaletteFloat();
-
-    const result = resolveColorFloat(1, false, grid, 0, true, palette, THEME_FG, THEME_BG);
+    const result = resolveColorFloat(1, false, 0, true, palette, THEME_FG, THEME_BG);
     expect(result).toBe(palette[1]);
     expect(result[0]).toBeCloseTo(1 / 255, 5);
   });
 
   it("returns palette color for non-default foreground index", () => {
-    const grid = new CellGrid(10, 5);
     const palette = makePaletteFloat();
-
-    const result = resolveColorFloat(196, false, grid, 0, true, palette, THEME_FG, THEME_BG);
+    const result = resolveColorFloat(196, false, 0, true, palette, THEME_FG, THEME_BG);
     expect(result).toBe(palette[196]);
   });
 
   it("returns palette color for non-default background index", () => {
-    const grid = new CellGrid(10, 5);
     const palette = makePaletteFloat();
-
-    const result = resolveColorFloat(4, false, grid, 0, false, palette, THEME_FG, THEME_BG);
+    const result = resolveColorFloat(4, false, 0, false, palette, THEME_FG, THEME_BG);
     expect(result).toBe(palette[4]);
   });
 
   it("returns theme fg for out-of-range foreground index (>=256)", () => {
-    const grid = new CellGrid(10, 5);
     const palette = makePaletteFloat();
-
-    const result = resolveColorFloat(256, false, grid, 0, true, palette, THEME_FG, THEME_BG);
+    const result = resolveColorFloat(256, false, 0, true, palette, THEME_FG, THEME_BG);
     expect(result).toBe(THEME_FG);
   });
 
   it("returns theme bg for out-of-range background index (>=256)", () => {
-    const grid = new CellGrid(10, 5);
     const palette = makePaletteFloat();
-
-    const result = resolveColorFloat(300, false, grid, 0, false, palette, THEME_FG, THEME_BG);
+    const result = resolveColorFloat(300, false, 0, false, palette, THEME_FG, THEME_BG);
     expect(result).toBe(THEME_BG);
   });
 
   it("returns RGB extracted color when isRGB=true for foreground", () => {
-    const grid = new CellGrid(10, 5);
     const palette = makePaletteFloat();
-    const col = 3;
-
     // Pack RGB: r=0xFF, g=0x00, b=0x00 (red)
-    grid.rgbColors[col] = 0xff0000;
-
-    const result = resolveColorFloat(0, true, grid, col, true, palette, THEME_FG, THEME_BG);
+    const result = resolveColorFloat(0, true, 0xff0000, true, palette, THEME_FG, THEME_BG);
     expect(result[0]).toBeCloseTo(1.0, 5);
     expect(result[1]).toBeCloseTo(0.0, 5);
     expect(result[2]).toBeCloseTo(0.0, 5);
@@ -98,14 +78,9 @@ describe("resolveColorFloat", () => {
   });
 
   it("returns RGB extracted color when isRGB=true for background", () => {
-    const grid = new CellGrid(10, 5);
     const palette = makePaletteFloat();
-    const col = 5;
-
-    // Pack RGB: r=0x00, g=0xFF, b=0x00 (green) at offset 256+col for background
-    grid.rgbColors[256 + col] = 0x00ff00;
-
-    const result = resolveColorFloat(0, true, grid, col, false, palette, THEME_FG, THEME_BG);
+    // Pack RGB: r=0x00, g=0xFF, b=0x00 (green)
+    const result = resolveColorFloat(0, true, 0x00ff00, false, palette, THEME_FG, THEME_BG);
     expect(result[0]).toBeCloseTo(0.0, 5);
     expect(result[1]).toBeCloseTo(1.0, 5);
     expect(result[2]).toBeCloseTo(0.0, 5);
@@ -113,14 +88,9 @@ describe("resolveColorFloat", () => {
   });
 
   it("RGB extraction correctly handles packed RGB (0xFF8000)", () => {
-    const grid = new CellGrid(10, 5);
     const palette = makePaletteFloat();
-    const col = 2;
-
     // Pack RGB: r=0xFF, g=0x80, b=0x00
-    grid.rgbColors[col] = 0xff8000;
-
-    const result = resolveColorFloat(0, true, grid, col, true, palette, THEME_FG, THEME_BG);
+    const result = resolveColorFloat(0, true, 0xff8000, true, palette, THEME_FG, THEME_BG);
     expect(result[0]).toBeCloseTo(1.0, 5); // 0xFF / 255
     expect(result[1]).toBeCloseTo(0x80 / 255, 5); // ~0.502
     expect(result[2]).toBeCloseTo(0.0, 5); // 0x00 / 255

--- a/packages/web/src/render-worker.ts
+++ b/packages/web/src/render-worker.ts
@@ -322,10 +322,9 @@ function createGridFromSAB(buffer: SharedArrayBuffer, c: number, r: number): Cel
   // Since CellGrid constructor allocates its own buffer, we need to construct
   // a lightweight wrapper that uses the shared buffer directly.
   const g = Object.create(CellGrid.prototype) as CellGrid;
-  const CELL_SIZE = 2;
+  const CELL_SIZE = 4;
   const cellBytes = c * r * CELL_SIZE * 4;
   const dirtyBytes = r * 4;
-  const rgbBytes = 512 * 4;
   const cursorBytes = 4 * 4;
 
   // Use Object.defineProperty to set readonly properties
@@ -340,16 +339,12 @@ function createGridFromSAB(buffer: SharedArrayBuffer, c: number, r: number): Cel
     value: new Int32Array(buffer, cellBytes, r),
     writable: false,
   });
-  Object.defineProperty(g, "rgbColors", {
-    value: new Uint32Array(buffer, cellBytes + dirtyBytes, 512),
-    writable: false,
-  });
   Object.defineProperty(g, "cursorData", {
-    value: new Int32Array(buffer, cellBytes + dirtyBytes + rgbBytes, 4),
+    value: new Int32Array(buffer, cellBytes + dirtyBytes, 4),
     writable: false,
   });
   Object.defineProperty(g, "rowOffsetData", {
-    value: new Int32Array(buffer, cellBytes + dirtyBytes + rgbBytes + cursorBytes, 1),
+    value: new Int32Array(buffer, cellBytes + dirtyBytes + cursorBytes, 1),
     writable: false,
   });
   // Set private buffer field for getBuffer()
@@ -564,8 +559,7 @@ function render(): void {
       let fg = resolveColorFloat(
         fgIdx,
         fgIsRGB,
-        grid,
-        col,
+        grid.getFgRGB(row, col),
         true,
         paletteFloat,
         themeFgFloat,
@@ -574,8 +568,7 @@ function render(): void {
       let bg = resolveColorFloat(
         bgIdx,
         bgIsRGB,
-        grid,
-        col,
+        grid.getBgRGB(row, col),
         false,
         paletteFloat,
         themeFgFloat,
@@ -643,8 +636,7 @@ function render(): void {
       let fg = resolveColorFloat(
         fgIdx,
         fgIsRGB,
-        grid,
-        col,
+        grid.getFgRGB(row, col),
         true,
         paletteFloat,
         themeFgFloat,
@@ -653,8 +645,7 @@ function render(): void {
       let bg = resolveColorFloat(
         bgIdx,
         bgIsRGB,
-        grid,
-        col,
+        grid.getBgRGB(row, col),
         false,
         paletteFloat,
         themeFgFloat,

--- a/packages/web/src/renderer.ts
+++ b/packages/web/src/renderer.ts
@@ -216,8 +216,8 @@ export class Canvas2DRenderer implements IRenderer {
         const effWidth = wide ? cellWidth * 2 : cellWidth;
 
         // Resolve colors
-        let fg = this.resolveCellColor(fgIdx, fgIsRGB, grid, col, true);
-        let bg = this.resolveCellColor(bgIdx, bgIsRGB, grid, col, false);
+        let fg = this.resolveCellColor(fgIdx, fgIsRGB, grid.getFgRGB(row, col), true);
+        let bg = this.resolveCellColor(bgIdx, bgIsRGB, grid.getBgRGB(row, col), false);
 
         // Handle inverse
         if (attrs & ATTR_INVERSE) {
@@ -446,22 +446,18 @@ export class Canvas2DRenderer implements IRenderer {
    * For indexed colors (fgIsRGB/bgIsRGB = false), colorIdx is the 256-color
    * palette index. Default foreground is index 7, default background is 0.
    *
-   * For RGB colors, the actual RGB value is stored in grid.rgbColors.
+   * For RGB colors, rgbValue contains the packed 24-bit color from cell word 2/3.
    */
   private resolveCellColor(
     colorIdx: number,
     isRGB: boolean,
-    grid: CellGrid,
-    col: number,
+    rgbValue: number,
     isForeground: boolean,
   ): string {
     if (isRGB) {
-      // Look up full RGB from the rgbColors table
-      const offset = isForeground ? col : 256 + col;
-      const rgb = grid.rgbColors[offset];
-      const r = (rgb >> 16) & 0xff;
-      const g = (rgb >> 8) & 0xff;
-      const b = rgb & 0xff;
+      const r = (rgbValue >> 16) & 0xff;
+      const g = (rgbValue >> 8) & 0xff;
+      const b = rgbValue & 0xff;
       return `rgb(${r},${g},${b})`;
     }
 

--- a/packages/web/src/shared-context.ts
+++ b/packages/web/src/shared-context.ts
@@ -832,8 +832,7 @@ export class SharedWebGLContext {
           let fg = resolveColorFloat(
             fgIdx,
             fgIsRGB,
-            grid,
-            col,
+            grid.getFgRGB(row, col),
             true,
             this.paletteFloat,
             this.themeFgFloat,
@@ -842,8 +841,7 @@ export class SharedWebGLContext {
           let bg = resolveColorFloat(
             bgIdx,
             bgIsRGB,
-            grid,
-            col,
+            grid.getBgRGB(row, col),
             false,
             this.paletteFloat,
             this.themeFgFloat,

--- a/packages/web/src/web-terminal.ts
+++ b/packages/web/src/web-terminal.ts
@@ -678,9 +678,10 @@ export class WebTerminal {
 
       // Scrollback rows (expand compact rows to full format for reflow)
       for (let i = 0; i < oldBufferSet.scrollback.length; i++) {
+        const raw = oldBufferSet.scrollback[i];
         const cells = oldBufferSet.scrollbackCompact[i]
-          ? expandCompactRow(oldBufferSet.scrollback[i], oldBufferSet.cols)
-          : oldBufferSet.scrollback[i];
+          ? expandCompactRow(raw, raw.length >>> 1)
+          : raw;
         allRows.push({
           cells,
           wrapped: oldBufferSet.scrollbackWrap[i] ?? false,

--- a/packages/web/src/web-terminal.ts
+++ b/packages/web/src/web-terminal.ts
@@ -19,6 +19,7 @@ import {
   CELL_SIZE,
   CellGrid,
   DEFAULT_THEME,
+  expandCompactRow,
   reflowRows,
   VTParser,
 } from "@next_term/core";
@@ -675,10 +676,13 @@ export class WebTerminal {
       // 1. Collect all rows: scrollback + viewport
       const allRows: RowData[] = [];
 
-      // Scrollback rows
+      // Scrollback rows (expand compact rows to full format for reflow)
       for (let i = 0; i < oldBufferSet.scrollback.length; i++) {
+        const cells = oldBufferSet.scrollbackCompact[i]
+          ? expandCompactRow(oldBufferSet.scrollback[i], oldBufferSet.cols)
+          : oldBufferSet.scrollback[i];
         allRows.push({
-          cells: oldBufferSet.scrollback[i],
+          cells,
           wrapped: oldBufferSet.scrollbackWrap[i] ?? false,
         });
       }
@@ -760,17 +764,20 @@ export class WebTerminal {
       // Transfer existing scrollback first, then push overflow rows.
       this.bufferSet.scrollback = oldBufferSet.scrollback;
       this.bufferSet.scrollbackWrap = oldBufferSet.scrollbackWrap;
+      this.bufferSet.scrollbackCompact = oldBufferSet.scrollbackCompact;
 
       // Push overflow rows (above the viewport) into scrollback so the
       // user can scroll up to see them (#162). Only for the normal buffer
       // — alt screen doesn't have scrollback. Skip when scrollback is
       // disabled (maxScrollback === 0) to avoid wasteful copying.
       if (srcStartRow > 0 && !oldBufferSet.isAlternate && scrollback > 0) {
-        const rowSize = oldGrid.cols * CELL_SIZE;
         for (let r = 0; r < srcStartRow; r++) {
-          const buf = this.bufferSet.borrowRowBuffer(rowSize);
-          oldGrid.copyRowInto(r, buf);
-          this.bufferSet.pushScrollback(buf, oldGrid.isWrapped(r));
+          const compact = oldGrid.copyRowCompact(r);
+          this.bufferSet.pushScrollback(
+            compact,
+            oldGrid.isWrapped(r),
+            compact.length < oldGrid.cols * CELL_SIZE,
+          );
         }
       }
 
@@ -1183,12 +1190,11 @@ export class WebTerminal {
         // Before scrollback — show empty
         this.displayGrid.clearRow(r);
       } else if (virtualLine < scrollback.length) {
-        // From scrollback
-        this.displayGrid.pasteRow(
-          r,
-          scrollback[virtualLine],
-          this.bufferSet.scrollbackWrap[virtualLine] ?? false,
-        );
+        // From scrollback (expand compact rows to full format for the grid)
+        const sbRow = this.bufferSet.scrollbackCompact[virtualLine]
+          ? expandCompactRow(scrollback[virtualLine], cols)
+          : scrollback[virtualLine];
+        this.displayGrid.pasteRow(r, sbRow, this.bufferSet.scrollbackWrap[virtualLine] ?? false);
       } else {
         // From live buffer
         const bufRow = virtualLine - scrollback.length;

--- a/packages/web/src/web-terminal.ts
+++ b/packages/web/src/web-terminal.ts
@@ -724,9 +724,27 @@ export class WebTerminal {
       );
 
       // Scrollback: everything before screenStart.
-      // Reflowed rows are already at newCols width with defaults filled.
+      // Reflowed rows are full-format; re-compact non-RGB rows to save memory.
       for (let i = 0; i < screenStart; i++) {
-        this.bufferSet.pushScrollback(reflowed[i].cells, reflowed[i].wrapped);
+        const cells = reflowed[i].cells;
+        let hasRgb = false;
+        const rowCols = cells.length / CELL_SIZE;
+        for (let c = 0; c < rowCols; c++) {
+          if (cells[c * CELL_SIZE] & ((1 << 21) | (1 << 22))) {
+            hasRgb = true;
+            break;
+          }
+        }
+        if (hasRgb) {
+          this.bufferSet.pushScrollback(cells, reflowed[i].wrapped);
+        } else {
+          const compact = new Uint32Array(rowCols * 2);
+          for (let c = 0; c < rowCols; c++) {
+            compact[c * 2] = cells[c * CELL_SIZE];
+            compact[c * 2 + 1] = cells[c * CELL_SIZE + 1];
+          }
+          this.bufferSet.pushScrollback(compact, reflowed[i].wrapped, true);
+        }
       }
 
       // Screen rows
@@ -1190,11 +1208,13 @@ export class WebTerminal {
         // Before scrollback — show empty
         this.displayGrid.clearRow(r);
       } else if (virtualLine < scrollback.length) {
-        // From scrollback (expand compact rows to full format for the grid)
-        const sbRow = this.bufferSet.scrollbackCompact[virtualLine]
-          ? expandCompactRow(scrollback[virtualLine], cols)
-          : scrollback[virtualLine];
-        this.displayGrid.pasteRow(r, sbRow, this.bufferSet.scrollbackWrap[virtualLine] ?? false);
+        // From scrollback — use pasteCompactRow for compact rows (no allocation)
+        const sbWrapped = this.bufferSet.scrollbackWrap[virtualLine] ?? false;
+        if (this.bufferSet.scrollbackCompact[virtualLine]) {
+          this.displayGrid.pasteCompactRow(r, scrollback[virtualLine], sbWrapped);
+        } else {
+          this.displayGrid.pasteRow(r, scrollback[virtualLine], sbWrapped);
+        }
       } else {
         // From live buffer
         const bufRow = virtualLine - scrollback.length;

--- a/packages/web/src/webgl-renderer.ts
+++ b/packages/web/src/webgl-renderer.ts
@@ -865,8 +865,7 @@ export class WebGLRenderer implements IRenderer {
         let fg = resolveColorFloat(
           fgIdx,
           fgIsRGB,
-          grid,
-          col,
+          grid.getFgRGB(row, col),
           true,
           this.paletteFloat,
           this.themeFgFloat,
@@ -875,8 +874,7 @@ export class WebGLRenderer implements IRenderer {
         let bg = resolveColorFloat(
           bgIdx,
           bgIsRGB,
-          grid,
-          col,
+          grid.getBgRGB(row, col),
           false,
           this.paletteFloat,
           this.themeFgFloat,

--- a/packages/web/src/webgl-utils.ts
+++ b/packages/web/src/webgl-utils.ts
@@ -1,23 +1,18 @@
-import type { CellGrid } from "@next_term/core";
-
 export type ColorFloat4 = [number, number, number, number];
 
 export function resolveColorFloat(
   colorIdx: number,
   isRGB: boolean,
-  grid: CellGrid,
-  col: number,
+  rgbValue: number,
   isForeground: boolean,
   paletteFloat: ColorFloat4[],
   themeFgFloat: ColorFloat4,
   themeBgFloat: ColorFloat4,
 ): ColorFloat4 {
   if (isRGB) {
-    const offset = isForeground ? col : 256 + col;
-    const rgb = grid.rgbColors[offset];
-    const r = ((rgb >> 16) & 0xff) / 255;
-    const g = ((rgb >> 8) & 0xff) / 255;
-    const b = (rgb & 0xff) / 255;
+    const r = ((rgbValue >> 16) & 0xff) / 255;
+    const g = ((rgbValue >> 8) & 0xff) / 255;
+    const b = (rgbValue & 0xff) / 255;
     return [r, g, b, 1.0];
   }
 


### PR DESCRIPTION
## Summary
- Fixes #146: `copyRow`/`pasteRow` now preserve truecolor (24-bit RGB) data
- Eliminates the column-indexed `rgbColors` table, which silently clobbered RGB values across rows
- Expands `CELL_SIZE` from 2 to 4 uint32 words, storing fg/bg RGB inline in each cell
- Scrollback uses compact format (2 words/cell) for non-RGB rows, eliminating the memory regression

## Test plan
- [x] All 1756 existing tests pass
- [x] New cross-row RGB preservation test verifies independent per-row colors
- [x] New compact scrollback round-trip test verifies expand/compact fidelity
- [x] Perf regression tests pass (no throughput regression)
- [x] Biome lint/format passes
- [ ] Manual: verify truecolor content (e.g., `bat` output) renders correctly after resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)