### PR TITLE
fix: zero-copy worker transfer, output coalescing, and demo fixes

### DIFF
--- a/packages/comparison/server.ts
+++ b/packages/comparison/server.ts
@@ -17,6 +17,10 @@ import { execSync } from "child_process";
 
 const PORT = 8090;
 
+// Coalesce PTY output over this interval before sending a WebSocket frame.
+// Reduces per-chunk ws.send() overhead dramatically.
+const COALESCE_MS = 4; // ~quarter frame at 60fps
+
 function findShell(): string {
   if (process.env.SHELL) return process.env.SHELL;
   for (const sh of ["/bin/zsh", "/bin/bash", "/bin/sh"]) {
@@ -30,15 +34,14 @@ function findShell(): string {
 
 const shell = findShell();
 
-// Workload definitions — commands that produce heavy, varied terminal output
-// All workloads produce continuous output — heavy enough to stress rendering,
-// throttled enough to not overwhelm the system at 16+ panes.
+// Workload definitions — commands that produce heavy, varied terminal output.
+// Designed to saturate the rendering pipeline without shell overhead.
 const WORKLOADS = [
   {
     name: "hex-dump",
     cmd: shell,
     args: [] as string[],
-    init: "while true; do head -c 4096 /dev/urandom | xxd; done\n",
+    init: "cat /dev/urandom | xxd\n",
   },
   {
     name: "log-stream",
@@ -59,7 +62,8 @@ const WORKLOADS = [
     name: "color-sgr",
     cmd: shell,
     args: [],
-    init: 'while true; do for i in $(seq 1 2000); do printf "\\033[38;5;$((i % 256));48;5;$((RANDOM % 256))m%02x" $((RANDOM % 256)); if [ $((i % 80)) -eq 0 ]; then echo; fi; done; done\n',
+    // Single awk process — no per-iteration fork overhead
+    init: `awk 'BEGIN{srand();while(1){for(i=0;i<80;i++){printf "\\033[38;5;%d;48;5;%dm%02x",int(rand()*256),int(rand()*256),int(rand()*256)}print "\\033[0m"}}'\n`,
   },
   {
     name: "find-deep",
@@ -83,7 +87,7 @@ const WORKLOADS = [
     name: "hex-dump-2",
     cmd: shell,
     args: [],
-    init: "while true; do head -c 4096 /dev/urandom | xxd; done\n",
+    init: "cat /dev/urandom | xxd\n",
   },
 ];
 
@@ -92,6 +96,37 @@ const wss = new WebSocketServer({ port: PORT });
 wss.on("connection", (ws: WebSocket) => {
   console.log("Client connected");
   const ptys: IPty[] = [];
+
+  // Per-pane coalescing buffers
+  const pendingChunks: Buffer[][] = [];
+  const pendingBytes: number[] = [];
+  const flushTimers: (ReturnType<typeof setTimeout> | null)[] = [];
+
+  function flushPane(paneIdx: number) {
+    flushTimers[paneIdx] = null;
+    const chunks = pendingChunks[paneIdx];
+    const totalLen = pendingBytes[paneIdx];
+    if (totalLen === 0 || ws.readyState !== ws.OPEN) {
+      chunks.length = 0;
+      pendingBytes[paneIdx] = 0;
+      return;
+    }
+
+    // Build a single frame: [paneIndex (1 byte)] + [coalesced data]
+    const frame = Buffer.allocUnsafe(1 + totalLen);
+    frame[0] = paneIdx;
+    let offset = 1;
+    for (const chunk of chunks) {
+      chunk.copy(frame, offset);
+      offset += chunk.length;
+    }
+    chunks.length = 0;
+    pendingBytes[paneIdx] = 0;
+
+    try {
+      ws.send(frame);
+    } catch {}
+  }
 
   ws.on("message", (msg: Buffer | ArrayBuffer | Buffer[], isBinary: boolean) => {
     if (isBinary) {
@@ -115,6 +150,10 @@ wss.on("connection", (ws: WebSocket) => {
 
       // Spawn PTYs — cycle workloads if paneCount > WORKLOADS.length
       for (let i = 0; i < paneCount; i++) {
+        pendingChunks.push([]);
+        pendingBytes.push(0);
+        flushTimers.push(null);
+
         const wl = WORKLOADS[i % WORKLOADS.length];
         try {
           const pty = spawn(wl.cmd, wl.args, {
@@ -130,16 +169,18 @@ wss.on("connection", (ws: WebSocket) => {
 
           ptys.push(pty);
 
-          // Forward PTY output as [paneIndex (1 byte)] + [data]
+          // Coalesce PTY output before sending
+          const paneIdx = i;
           pty.onData((output: string) => {
             if (ws.readyState !== ws.OPEN) return;
-            const outBuf = Buffer.from(output, "utf-8");
-            const frame = Buffer.allocUnsafe(1 + outBuf.length);
-            frame[0] = i;
-            outBuf.copy(frame, 1);
-            try {
-              ws.send(frame);
-            } catch {}
+            const buf = Buffer.from(output, "utf-8");
+            pendingChunks[paneIdx].push(buf);
+            pendingBytes[paneIdx] += buf.length;
+
+            // Schedule a flush if one isn't pending
+            if (flushTimers[paneIdx] === null) {
+              flushTimers[paneIdx] = setTimeout(flushPane, COALESCE_MS, paneIdx);
+            }
           });
 
           pty.onExit(() => {
@@ -182,6 +223,9 @@ wss.on("connection", (ws: WebSocket) => {
 
   ws.on("close", () => {
     console.log("Client disconnected — killing PTYs");
+    for (let i = 0; i < flushTimers.length; i++) {
+      if (flushTimers[i] !== null) clearTimeout(flushTimers[i]!);
+    }
     for (const pty of ptys) {
       try {
         pty.kill();

--- a/packages/comparison/src/metrics.ts
+++ b/packages/comparison/src/metrics.ts
@@ -133,7 +133,7 @@ export class MetricsTracker {
     this.panel.innerHTML = `
       <div class="metrics-title">${this.terminalName}</div>
       <table class="metrics-table">
-        <tr><td>FPS</td><td class="${m.fps < 30 ? "warn" : "good"}">${m.fps.toFixed(1)}</td></tr>
+        <tr><td>Page FPS</td><td class="${m.fps < 30 ? "warn" : "good"}">${m.fps.toFixed(1)}</td></tr>
         <tr><td>Frame p50</td><td>${m.frameTimeP50.toFixed(1)} ms</td></tr>
         <tr><td>Frame p95</td><td class="${m.frameTimeP95 > 33 ? "warn" : ""}">${m.frameTimeP95.toFixed(1)} ms</td></tr>
         <tr><td>Frame p99</td><td class="${m.frameTimeP99 > 50 ? "warn" : ""}">${m.frameTimeP99.toFixed(1)} ms</td></tr>

--- a/packages/comparison/src/mux-client.ts
+++ b/packages/comparison/src/mux-client.ts
@@ -38,7 +38,9 @@ export class MuxClient {
         // Binary: [paneIndex (1 byte)] + [data]
         const buf = new Uint8Array(ev.data as ArrayBuffer);
         const paneIndex = buf[0];
-        const data = buf.subarray(1);
+        // Copy into an owned buffer so the worker bridge can transfer
+        // (subarray keeps byteOffset=1 which defeats zero-copy transfer)
+        const data = buf.slice(1);
         this.callbacks.onData(paneIndex, data);
       }
     };
@@ -54,9 +56,9 @@ export class MuxClient {
 
   private encoder = new TextEncoder();
 
-  sendInput(paneIndex: number, data: string) {
+  sendInput(paneIndex: number, data: string | Uint8Array) {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
-    const encoded = this.encoder.encode(data);
+    const encoded = typeof data === "string" ? this.encoder.encode(data) : data;
     const frame = new Uint8Array(1 + encoded.length);
     frame[0] = paneIndex;
     frame.set(encoded, 1);

--- a/packages/comparison/src/react-term-page.ts
+++ b/packages/comparison/src/react-term-page.ts
@@ -140,8 +140,9 @@ $("status-mode").textContent = `${PANE_COUNT} panes · react-term (${mode})`;
 const client = new MuxClient({
   onData(paneIndex, data) {
     if (paneIndex < terminals.length) {
+      const len = data.byteLength; // capture before write() transfers the buffer
       terminals[paneIndex].write(data);
-      metrics.recordBytes(data.byteLength, paneIndex);
+      metrics.recordBytes(len, paneIndex);
     }
   },
   onReady(paneNames) {
@@ -162,11 +163,10 @@ const client = new MuxClient({
 });
 
 // Wire input
-const decoder = new TextDecoder();
 for (let i = 0; i < PANE_COUNT; i++) {
   const idx = i;
   terminals[idx].onData((data: Uint8Array) => {
-    client.sendInput(idx, decoder.decode(data));
+    client.sendInput(idx, data);
   });
 }
 

--- a/packages/demo/src/main.tsx
+++ b/packages/demo/src/main.tsx
@@ -318,7 +318,9 @@ function App() {
     };
 
     ws.onclose = () => {
-      wsRef.current = null;
+      // Only clear the ref if it still points to this socket — a newer
+      // connection may have replaced it while this one was CLOSING.
+      if (wsRef.current === ws) wsRef.current = null;
       if (modeRef.current === "pty") {
         // Was connected, now disconnected — show message and fall back
         modeRef.current = "local";
@@ -432,7 +434,29 @@ function App() {
 
       // Local echo mode: mini shell
       const str = new TextDecoder().decode(data);
-      for (const ch of str) {
+      let i = 0;
+      while (i < str.length) {
+        const ch = str[i];
+
+        // Skip escape sequences (CSI, SS3, etc.) so arrow keys and
+        // other special keys don't leak bracket characters into input.
+        if (ch === "\x1b") {
+          i++;
+          if (i < str.length && str[i] === "[") {
+            // CSI sequence: consume until final byte (0x40–0x7E)
+            i++;
+            while (i < str.length && str.charCodeAt(i) < 0x40) i++;
+            if (i < str.length) i++; // skip final byte
+          } else if (i < str.length && str[i] === "O") {
+            // SS3 sequence (e.g. \x1bOA): skip next byte
+            i += 2;
+          } else {
+            // Bare ESC or unrecognised — skip one byte
+            if (i < str.length) i++;
+          }
+          continue;
+        }
+
         if (ch === "\r") {
           const cmd = lineBufferRef.current.trim();
           lineBufferRef.current = "";
@@ -456,6 +480,7 @@ function App() {
           lineBufferRef.current += ch;
           term.write(ch);
         }
+        i++;
       }
     },
     [executeCommand],
@@ -527,7 +552,25 @@ function SplitPaneDemo({ theme, onBack }: { theme: Partial<Theme>; onBack: () =>
     if (!lineBuffers.current[paneId]) lineBuffers.current[paneId] = "";
 
     const str = new TextDecoder().decode(data);
-    for (const ch of str) {
+    let i = 0;
+    while (i < str.length) {
+      const ch = str[i];
+
+      // Skip escape sequences (arrow keys, etc.)
+      if (ch === "\x1b") {
+        i++;
+        if (i < str.length && str[i] === "[") {
+          i++;
+          while (i < str.length && str.charCodeAt(i) < 0x40) i++;
+          if (i < str.length) i++;
+        } else if (i < str.length && str[i] === "O") {
+          i += 2;
+        } else {
+          if (i < str.length) i++;
+        }
+        continue;
+      }
+
       if (ch === "\r") {
         const cmd = lineBuffers.current[paneId].trim();
         lineBuffers.current[paneId] = "";
@@ -547,6 +590,7 @@ function SplitPaneDemo({ theme, onBack }: { theme: Partial<Theme>; onBack: () =>
         lineBuffers.current[paneId] += ch;
         term.write(ch);
       }
+      i++;
     }
   }, []);
 

--- a/packages/e2e-bench/src/components/MultiPaneBenchmarkRunner.tsx
+++ b/packages/e2e-bench/src/components/MultiPaneBenchmarkRunner.tsx
@@ -209,6 +209,10 @@ export function MultiPaneBenchmarkRunner({ config, onResult, onProgress, onCompl
   // Render react-term multi-pane
   if (activeTerminal?.terminal === "react-term") {
     const layout = buildLayout(activeTerminal.paneCount);
+    // Size the pool to match the pane count up to the default cap (4) so
+    // low-pane-count benchmarks aren't skewed by idle workers. At 8+ panes
+    // this stops growing and workers serve multiple channels each.
+    const parserWorkers = Math.min(activeTerminal.paneCount, 4);
     return (
       <div
         style={{
@@ -219,7 +223,12 @@ export function MultiPaneBenchmarkRunner({ config, onResult, onProgress, onCompl
           overflow: "hidden",
         }}
       >
-        <TerminalPane ref={paneRef} layout={layout} style={{ width: "100%", height: "100%" }} />
+        <TerminalPane
+          ref={paneRef}
+          layout={layout}
+          parserWorkers={parserWorkers}
+          style={{ width: "100%", height: "100%" }}
+        />
       </div>
     );
   }

--- a/packages/e2e-bench/src/components/MultiPaneBenchmarkRunner.tsx
+++ b/packages/e2e-bench/src/components/MultiPaneBenchmarkRunner.tsx
@@ -209,9 +209,6 @@ export function MultiPaneBenchmarkRunner({ config, onResult, onProgress, onCompl
   // Render react-term multi-pane
   if (activeTerminal?.terminal === "react-term") {
     const layout = buildLayout(activeTerminal.paneCount);
-    // Disable per-pane workers at high pane counts — the postMessage
-    // overhead of N workers exceeds the benefit of parallel parsing.
-    const useWorker = activeTerminal.paneCount <= 8;
     return (
       <div
         style={{
@@ -222,12 +219,7 @@ export function MultiPaneBenchmarkRunner({ config, onResult, onProgress, onCompl
           overflow: "hidden",
         }}
       >
-        <TerminalPane
-          ref={paneRef}
-          layout={layout}
-          useWorker={useWorker}
-          style={{ width: "100%", height: "100%" }}
-        />
+        <TerminalPane ref={paneRef} layout={layout} style={{ width: "100%", height: "100%" }} />
       </div>
     );
   }

--- a/packages/e2e-bench/src/components/MultiPaneBenchmarkRunner.tsx
+++ b/packages/e2e-bench/src/components/MultiPaneBenchmarkRunner.tsx
@@ -98,14 +98,14 @@ export function MultiPaneBenchmarkRunner({ config, onResult, onProgress, onCompl
             if (settled) return;
             if (event.data instanceof ArrayBuffer) {
               const buf = event.data as ArrayBuffer;
-              recordWrite(buf.byteLength);
-
               const data = new Uint8Array(buf);
+              const len = data.byteLength; // capture before write() may transfer the buffer
               if (terminal === "react-term") {
                 paneRef.current?.getTerminal(`pane-${i}`)?.write(data);
               } else {
                 xtermRefs.current.get(i)?.write(data);
               }
+              recordWrite(len);
             } else {
               let msg: { type?: string; serverElapsedMs?: number; totalBytes?: number };
               try {

--- a/packages/e2e-bench/src/components/MultiPaneBenchmarkRunner.tsx
+++ b/packages/e2e-bench/src/components/MultiPaneBenchmarkRunner.tsx
@@ -209,6 +209,9 @@ export function MultiPaneBenchmarkRunner({ config, onResult, onProgress, onCompl
   // Render react-term multi-pane
   if (activeTerminal?.terminal === "react-term") {
     const layout = buildLayout(activeTerminal.paneCount);
+    // Disable per-pane workers at high pane counts — the postMessage
+    // overhead of N workers exceeds the benefit of parallel parsing.
+    const useWorker = activeTerminal.paneCount <= 8;
     return (
       <div
         style={{
@@ -219,7 +222,12 @@ export function MultiPaneBenchmarkRunner({ config, onResult, onProgress, onCompl
           overflow: "hidden",
         }}
       >
-        <TerminalPane ref={paneRef} layout={layout} style={{ width: "100%", height: "100%" }} />
+        <TerminalPane
+          ref={paneRef}
+          layout={layout}
+          useWorker={useWorker}
+          style={{ width: "100%", height: "100%" }}
+        />
       </div>
     );
   }

--- a/packages/e2e-bench/src/components/MuxBenchmarkRunner.tsx
+++ b/packages/e2e-bench/src/components/MuxBenchmarkRunner.tsx
@@ -211,6 +211,8 @@ export function MuxBenchmarkRunner({ config, onResult, onProgress, onComplete }:
   // Render react-term multi-pane
   if (activeTerminal?.terminal === "react-term") {
     const layout = buildLayout(activeTerminal.paneCount);
+    // Size the pool to match the pane count up to the default cap (4).
+    const parserWorkers = Math.min(activeTerminal.paneCount, 4);
     return (
       <div
         style={{
@@ -221,7 +223,12 @@ export function MuxBenchmarkRunner({ config, onResult, onProgress, onComplete }:
           overflow: "hidden",
         }}
       >
-        <TerminalPane ref={paneRef} layout={layout} style={{ width: "100%", height: "100%" }} />
+        <TerminalPane
+          ref={paneRef}
+          layout={layout}
+          parserWorkers={parserWorkers}
+          style={{ width: "100%", height: "100%" }}
+        />
       </div>
     );
   }

--- a/packages/e2e-bench/src/components/MuxBenchmarkRunner.tsx
+++ b/packages/e2e-bench/src/components/MuxBenchmarkRunner.tsx
@@ -211,6 +211,7 @@ export function MuxBenchmarkRunner({ config, onResult, onProgress, onComplete }:
   // Render react-term multi-pane
   if (activeTerminal?.terminal === "react-term") {
     const layout = buildLayout(activeTerminal.paneCount);
+    const useWorker = activeTerminal.paneCount <= 8;
     return (
       <div
         style={{
@@ -221,7 +222,12 @@ export function MuxBenchmarkRunner({ config, onResult, onProgress, onComplete }:
           overflow: "hidden",
         }}
       >
-        <TerminalPane ref={paneRef} layout={layout} style={{ width: "100%", height: "100%" }} />
+        <TerminalPane
+          ref={paneRef}
+          layout={layout}
+          useWorker={useWorker}
+          style={{ width: "100%", height: "100%" }}
+        />
       </div>
     );
   }

--- a/packages/e2e-bench/src/components/MuxBenchmarkRunner.tsx
+++ b/packages/e2e-bench/src/components/MuxBenchmarkRunner.tsx
@@ -211,7 +211,6 @@ export function MuxBenchmarkRunner({ config, onResult, onProgress, onComplete }:
   // Render react-term multi-pane
   if (activeTerminal?.terminal === "react-term") {
     const layout = buildLayout(activeTerminal.paneCount);
-    const useWorker = activeTerminal.paneCount <= 8;
     return (
       <div
         style={{
@@ -222,12 +221,7 @@ export function MuxBenchmarkRunner({ config, onResult, onProgress, onComplete }:
           overflow: "hidden",
         }}
       >
-        <TerminalPane
-          ref={paneRef}
-          layout={layout}
-          useWorker={useWorker}
-          style={{ width: "100%", height: "100%" }}
-        />
+        <TerminalPane ref={paneRef} layout={layout} style={{ width: "100%", height: "100%" }} />
       </div>
     );
   }

--- a/packages/e2e-bench/src/components/MuxBenchmarkRunner.tsx
+++ b/packages/e2e-bench/src/components/MuxBenchmarkRunner.tsx
@@ -102,15 +102,17 @@ export function MuxBenchmarkRunner({ config, onResult, onProgress, onComplete }:
             // First 2 bytes: LE pane index
             const header = new DataView(buf);
             const paneIndex = header.getUint16(0, true);
-            const payload = new Uint8Array(buf, 2);
+            // slice() (not a view) so the worker bridge can transfer the
+            // owned ArrayBuffer — a view at offset 2 defeats zero-copy.
+            const payload = new Uint8Array(buf).slice(2);
 
-            recordWrite(payload.byteLength);
-
+            const len = payload.byteLength; // capture before write() may transfer the buffer
             if (terminal === "react-term") {
               paneRef.current?.getTerminal(`pane-${paneIndex}`)?.write(payload);
             } else {
               xtermRefs.current.get(paneIndex)?.write(payload);
             }
+            recordWrite(len);
           } else {
             let msg: { type?: string; serverElapsedMs?: number; totalBytes?: number };
             try {

--- a/packages/e2e-bench/tests/multi-pane-benchmark.spec.ts
+++ b/packages/e2e-bench/tests/multi-pane-benchmark.spec.ts
@@ -9,7 +9,8 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const TERMINALS = ['react-term', 'xterm'] as const;
-const PANE_COUNTS = [2, 4, 8, 16, 32] as const;
+// Capped at 16 — 32 panes is an unrealistic workload for most users.
+const PANE_COUNTS = [2, 4, 8, 16] as const;
 const SCENARIO = 'sgr-color';
 const WARMUP_RUNS = 2;
 const MEASURED_RUNS = 5;

--- a/packages/e2e-bench/tests/mux-benchmark.spec.ts
+++ b/packages/e2e-bench/tests/mux-benchmark.spec.ts
@@ -9,7 +9,10 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const TERMINALS = ['react-term', 'xterm'] as const;
-const PANE_COUNTS = [2, 4, 8, 16, 32] as const;
+// Capped at 16 — 32 panes is an unrealistic workload (few users run that many
+// terminals) and the full 70-iteration matrix exceeded the 10-min Playwright
+// test timeout, so mux results were never recorded on CI.
+const PANE_COUNTS = [2, 4, 8, 16] as const;
 const SCENARIO = 'sgr-color';
 const WARMUP_RUNS = 2;
 const MEASURED_RUNS = 5;

--- a/packages/react/src/Terminal.tsx
+++ b/packages/react/src/Terminal.tsx
@@ -29,7 +29,8 @@ export interface TerminalProps {
   useWorker?: boolean;
   /** Shared WebGL context for multi-pane rendering. */
   sharedContext?: SharedWebGLContext;
-  /** Pane ID within the shared context. Required when sharedContext is provided. */
+  /** Unique identifier for this pane. Required when `sharedContext` or
+   *  `parserPool` is provided — it's used as the channel id in both. */
   paneId?: string;
   /** Shared parser worker pool for multi-pane parsing. */
   parserPool?: ParserPool;

--- a/packages/react/src/Terminal.tsx
+++ b/packages/react/src/Terminal.tsx
@@ -1,5 +1,5 @@
 import type { MouseEncoding, MouseProtocol, Theme } from "@next_term/core";
-import type { SharedWebGLContext } from "@next_term/web";
+import type { ParserPool, SharedWebGLContext } from "@next_term/web";
 import { calculateFit, WebTerminal } from "@next_term/web";
 import type React from "react";
 import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
@@ -31,6 +31,8 @@ export interface TerminalProps {
   sharedContext?: SharedWebGLContext;
   /** Pane ID within the shared context. Required when sharedContext is provided. */
   paneId?: string;
+  /** Shared parser worker pool for multi-pane parsing. */
+  parserPool?: ParserPool;
 }
 
 export interface TerminalHandle {
@@ -78,6 +80,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     useWorker,
     sharedContext,
     paneId,
+    parserPool,
   } = props;
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -178,6 +181,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       useWorker,
       sharedContext,
       paneId,
+      parserPool,
       onData: (data: Uint8Array) => onDataRef.current?.(data),
       onResize: (size: { cols: number; rows: number }) => onResizeRef.current?.(size),
       onTitleChange: (title: string) => onTitleChangeRef.current?.(title),
@@ -204,6 +208,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     sharedContext,
     theme,
     useWorker,
+    parserPool,
   ]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Update theme when it changes

--- a/packages/react/src/TerminalPane.tsx
+++ b/packages/react/src/TerminalPane.tsx
@@ -284,6 +284,23 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
     const sharedContextRef = useRef<SharedWebGLContext | null>(null);
     const [sharedContext, setSharedContext] = useState<SharedWebGLContext | null>(null);
 
+    // Warn on duplicate pane ids — the pool rejects them at acquire time,
+    // which causes WebTerminal to silently fall back to main-thread parsing.
+    useEffect(() => {
+      const ids = collectPaneIds(layout);
+      const seen = new Set<string>();
+      const duplicates: string[] = [];
+      for (const id of ids) {
+        if (seen.has(id)) duplicates.push(id);
+        seen.add(id);
+      }
+      if (duplicates.length > 0) {
+        console.warn(
+          `[TerminalPane] duplicate pane ids in layout: ${duplicates.join(", ")}. Each leaf must have a unique id.`,
+        );
+      }
+    }, [layout]);
+
     // Create the parser pool in a useEffect so StrictMode's double-invoke
     // of lazy initializers can't leak workers. Children render a placeholder
     // until the pool decision is committed (mounted=true), which prevents the

--- a/packages/react/src/TerminalPane.tsx
+++ b/packages/react/src/TerminalPane.tsx
@@ -31,6 +31,8 @@ export interface TerminalPaneProps {
   fontFamily?: string;
   fontWeight?: number;
   fontWeightBold?: number;
+  /** Control whether each pane uses a Web Worker for parsing. Defaults to auto-detect (SAB available). */
+  useWorker?: boolean;
   className?: string;
   style?: React.CSSProperties;
 }
@@ -60,6 +62,7 @@ interface PaneLeafProps {
   fontFamily?: string;
   fontWeight?: number;
   fontWeightBold?: number;
+  useWorker?: boolean;
   onRef: (id: string, handle: TerminalHandle | null) => void;
   sharedContext: SharedWebGLContext | null;
 }
@@ -72,6 +75,7 @@ function PaneLeaf({
   fontFamily,
   fontWeight,
   fontWeightBold,
+  useWorker,
   onRef,
   sharedContext,
 }: PaneLeafProps) {
@@ -126,6 +130,7 @@ function PaneLeaf({
         fontFamily={fontFamily}
         fontWeight={fontWeight}
         fontWeightBold={fontWeightBold}
+        useWorker={useWorker}
         onData={handleData}
         sharedContext={sharedContext ?? undefined}
         paneId={sharedContext ? id : undefined}
@@ -147,6 +152,7 @@ interface PaneNodeProps {
   fontFamily?: string;
   fontWeight?: number;
   fontWeightBold?: number;
+  useWorker?: boolean;
   onRef: (id: string, handle: TerminalHandle | null) => void;
   sharedContext: SharedWebGLContext | null;
 }
@@ -159,6 +165,7 @@ function PaneNode({
   fontFamily,
   fontWeight,
   fontWeightBold,
+  useWorker,
   onRef,
   sharedContext,
 }: PaneNodeProps) {
@@ -172,6 +179,7 @@ function PaneNode({
         fontFamily={fontFamily}
         fontWeight={fontWeight}
         fontWeightBold={fontWeightBold}
+        useWorker={useWorker}
         onRef={onRef}
         sharedContext={sharedContext}
       />
@@ -218,6 +226,7 @@ function PaneNode({
               fontFamily={fontFamily}
               fontWeight={fontWeight}
               fontWeightBold={fontWeightBold}
+              useWorker={useWorker}
               onRef={onRef}
               sharedContext={sharedContext}
             />
@@ -242,6 +251,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
       fontFamily,
       fontWeight,
       fontWeightBold,
+      useWorker,
       className,
       style,
     } = props;
@@ -367,6 +377,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
           fontFamily={fontFamily}
           fontWeight={fontWeight}
           fontWeightBold={fontWeightBold}
+          useWorker={useWorker}
           onRef={handleRef}
           sharedContext={sharedContext}
         />

--- a/packages/react/src/TerminalPane.tsx
+++ b/packages/react/src/TerminalPane.tsx
@@ -272,23 +272,34 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
     const sharedContextRef = useRef<SharedWebGLContext | null>(null);
     const [sharedContext, setSharedContext] = useState<SharedWebGLContext | null>(null);
 
-    // Create parser pool synchronously so children see it on the first render.
-    // A deferred useEffect would cause each pane to first mount with a per-pane
-    // worker, then tear down and re-acquire from the pool — wasteful churn
-    // (e.g. 32 panes → 32 wasted Worker creations).
-    // parserWorkers === 0 disables the pool entirely (panes get per-pane workers).
-    const paneCount = collectPaneIds(layout).length;
-    const [parserPool] = useState<ParserPool | null>(() => {
-      if (useWorker === false || parserWorkers === 0 || paneCount === 0) return null;
-      // Cap pool size at paneCount — no point spawning 4 workers for 1 pane.
-      const requestedCount = parserWorkers ?? DEFAULT_PARSER_WORKER_COUNT;
-      const effectiveCount = Math.min(requestedCount, paneCount);
-      try {
-        return new ParserPool(effectiveCount);
-      } catch {
-        return null;
+    // Create the parser pool in a useEffect so StrictMode's double-invoke
+    // of lazy initializers can't leak workers. Children render a placeholder
+    // until the pool decision is committed (mounted=true), which prevents the
+    // first-render race where panes would create per-pane WorkerBridges only
+    // to tear them down once the pool arrived.
+    const [mounted, setMounted] = useState(false);
+    const [parserPool, setParserPool] = useState<ParserPool | null>(null);
+
+    useEffect(() => {
+      if (useWorker === false || parserWorkers === 0) {
+        setParserPool(null);
+        setMounted(true);
+        return;
       }
-    });
+      let pool: ParserPool | null = null;
+      try {
+        pool = new ParserPool(parserWorkers ?? DEFAULT_PARSER_WORKER_COUNT);
+      } catch {
+        pool = null;
+      }
+      setParserPool(pool);
+      setMounted(true);
+      return () => {
+        pool?.dispose();
+        setParserPool(null);
+        setMounted(false);
+      };
+    }, [useWorker, parserWorkers]);
 
     const handleRef = useCallback((id: string, handle: TerminalHandle | null) => {
       if (handle) {
@@ -376,14 +387,6 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
       }
     }, [theme]);
 
-    // Dispose the parser pool on unmount. The pool itself was created
-    // synchronously via useState lazy init above.
-    useEffect(() => {
-      return () => {
-        parserPool?.dispose();
-      };
-    }, [parserPool]);
-
     useImperativeHandle(
       ref,
       () => ({
@@ -407,19 +410,21 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
           ...style,
         }}
       >
-        <PaneNode
-          layout={layout}
-          onData={onData}
-          theme={theme}
-          fontSize={fontSize}
-          fontFamily={fontFamily}
-          fontWeight={fontWeight}
-          fontWeightBold={fontWeightBold}
-          useWorker={useWorker}
-          parserPool={parserPool}
-          onRef={handleRef}
-          sharedContext={sharedContext}
-        />
+        {mounted && (
+          <PaneNode
+            layout={layout}
+            onData={onData}
+            theme={theme}
+            fontSize={fontSize}
+            fontFamily={fontFamily}
+            fontWeight={fontWeight}
+            fontWeightBold={fontWeightBold}
+            useWorker={useWorker}
+            parserPool={parserPool}
+            onRef={handleRef}
+            sharedContext={sharedContext}
+          />
+        )}
       </div>
     );
   },

--- a/packages/react/src/TerminalPane.tsx
+++ b/packages/react/src/TerminalPane.tsx
@@ -33,9 +33,21 @@ export interface TerminalPaneProps {
   fontWeightBold?: number;
   /** Control whether each pane uses a Web Worker for parsing. Defaults to auto-detect (SAB available). */
   useWorker?: boolean;
-  /** Number of shared parser workers. Panes share a pool instead of each spawning
-   *  their own worker. Set 0 to disable the pool (each pane gets its own worker
-   *  via useWorker instead). Default: auto (~4). */
+  /**
+   * Number of shared parser workers. All panes share a pool of this many
+   * workers, routed round-robin by the channel id (pane id).
+   *
+   * - `undefined` (default): `min(navigator.hardwareConcurrency ?? 4, 4)`.
+   *   Suitable for multi-pane layouts; at 1–2 panes the unused workers
+   *   cost ~1–2 MB RAM each and sit idle.
+   * - A positive integer: that exact number of workers.
+   * - `0`: disable the shared pool entirely. Each pane gets its own
+   *   dedicated worker via `useWorker`, same as a standalone `<Terminal>`.
+   *
+   * Changing this prop at runtime disposes the current pool and recreates
+   * it — which tears down all pane terminal state. Treat it as a
+   * mount-time setting in practice.
+   */
   parserWorkers?: number;
   className?: string;
   style?: React.CSSProperties;

--- a/packages/react/src/TerminalPane.tsx
+++ b/packages/react/src/TerminalPane.tsx
@@ -10,7 +10,7 @@
  */
 
 import type { Theme } from "@next_term/core";
-import { ParserPool, SharedWebGLContext } from "@next_term/web";
+import { DEFAULT_PARSER_WORKER_COUNT, ParserPool, SharedWebGLContext } from "@next_term/web";
 import type React from "react";
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { collectPaneIds, type PaneLayout } from "./pane-layout.js";
@@ -34,7 +34,8 @@ export interface TerminalPaneProps {
   /** Control whether each pane uses a Web Worker for parsing. Defaults to auto-detect (SAB available). */
   useWorker?: boolean;
   /** Number of shared parser workers. Panes share a pool instead of each spawning
-   *  their own worker. Set 0 to disable workers entirely. Default: auto (~4). */
+   *  their own worker. Set 0 to disable the pool (each pane gets its own worker
+   *  via useWorker instead). Default: auto (~4). */
   parserWorkers?: number;
   className?: string;
   style?: React.CSSProperties;
@@ -139,7 +140,7 @@ function PaneLeaf({
         parserPool={parserPool ?? undefined}
         onData={handleData}
         sharedContext={sharedContext ?? undefined}
-        paneId={sharedContext ? id : undefined}
+        paneId={sharedContext || parserPool ? id : undefined}
         style={{ width: "100%", height: "100%" }}
       />
     </div>
@@ -270,8 +271,24 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
     const terminalsRef = useRef<Map<string, TerminalHandle>>(new Map());
     const sharedContextRef = useRef<SharedWebGLContext | null>(null);
     const [sharedContext, setSharedContext] = useState<SharedWebGLContext | null>(null);
-    const parserPoolRef = useRef<ParserPool | null>(null);
-    const [parserPool, setParserPool] = useState<ParserPool | null>(null);
+
+    // Create parser pool synchronously so children see it on the first render.
+    // A deferred useEffect would cause each pane to first mount with a per-pane
+    // worker, then tear down and re-acquire from the pool — wasteful churn
+    // (e.g. 32 panes → 32 wasted Worker creations).
+    // parserWorkers === 0 disables the pool entirely (panes get per-pane workers).
+    const paneCount = collectPaneIds(layout).length;
+    const [parserPool] = useState<ParserPool | null>(() => {
+      if (useWorker === false || parserWorkers === 0 || paneCount === 0) return null;
+      // Cap pool size at paneCount — no point spawning 4 workers for 1 pane.
+      const requestedCount = parserWorkers ?? DEFAULT_PARSER_WORKER_COUNT;
+      const effectiveCount = Math.min(requestedCount, paneCount);
+      try {
+        return new ParserPool(effectiveCount);
+      } catch {
+        return null;
+      }
+    });
 
     const handleRef = useCallback((id: string, handle: TerminalHandle | null) => {
       if (handle) {
@@ -359,24 +376,13 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
       }
     }, [theme]);
 
-    // Create and manage the shared parser worker pool.
-    // When useWorker is explicitly false, skip pool creation.
+    // Dispose the parser pool on unmount. The pool itself was created
+    // synchronously via useState lazy init above.
     useEffect(() => {
-      if (useWorker === false) return;
-      try {
-        const pool = new ParserPool(parserWorkers);
-        parserPoolRef.current = pool;
-        setParserPool(pool);
-        return () => {
-          pool.dispose();
-          parserPoolRef.current = null;
-          setParserPool(null);
-        };
-      } catch {
-        // Pool creation failed — fall back to per-pane workers
-        return;
-      }
-    }, [parserWorkers, useWorker]);
+      return () => {
+        parserPool?.dispose();
+      };
+    }, [parserPool]);
 
     useImperativeHandle(
       ref,

--- a/packages/react/src/TerminalPane.tsx
+++ b/packages/react/src/TerminalPane.tsx
@@ -10,7 +10,7 @@
  */
 
 import type { Theme } from "@next_term/core";
-import { SharedWebGLContext } from "@next_term/web";
+import { ParserPool, SharedWebGLContext } from "@next_term/web";
 import type React from "react";
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { collectPaneIds, type PaneLayout } from "./pane-layout.js";
@@ -33,6 +33,9 @@ export interface TerminalPaneProps {
   fontWeightBold?: number;
   /** Control whether each pane uses a Web Worker for parsing. Defaults to auto-detect (SAB available). */
   useWorker?: boolean;
+  /** Number of shared parser workers. Panes share a pool instead of each spawning
+   *  their own worker. Set 0 to disable workers entirely. Default: auto (~4). */
+  parserWorkers?: number;
   className?: string;
   style?: React.CSSProperties;
 }
@@ -63,6 +66,7 @@ interface PaneLeafProps {
   fontWeight?: number;
   fontWeightBold?: number;
   useWorker?: boolean;
+  parserPool?: ParserPool | null;
   onRef: (id: string, handle: TerminalHandle | null) => void;
   sharedContext: SharedWebGLContext | null;
 }
@@ -76,6 +80,7 @@ function PaneLeaf({
   fontWeight,
   fontWeightBold,
   useWorker,
+  parserPool,
   onRef,
   sharedContext,
 }: PaneLeafProps) {
@@ -131,6 +136,7 @@ function PaneLeaf({
         fontWeight={fontWeight}
         fontWeightBold={fontWeightBold}
         useWorker={useWorker}
+        parserPool={parserPool ?? undefined}
         onData={handleData}
         sharedContext={sharedContext ?? undefined}
         paneId={sharedContext ? id : undefined}
@@ -153,6 +159,7 @@ interface PaneNodeProps {
   fontWeight?: number;
   fontWeightBold?: number;
   useWorker?: boolean;
+  parserPool?: ParserPool | null;
   onRef: (id: string, handle: TerminalHandle | null) => void;
   sharedContext: SharedWebGLContext | null;
 }
@@ -166,6 +173,7 @@ function PaneNode({
   fontWeight,
   fontWeightBold,
   useWorker,
+  parserPool,
   onRef,
   sharedContext,
 }: PaneNodeProps) {
@@ -180,6 +188,7 @@ function PaneNode({
         fontWeight={fontWeight}
         fontWeightBold={fontWeightBold}
         useWorker={useWorker}
+        parserPool={parserPool}
         onRef={onRef}
         sharedContext={sharedContext}
       />
@@ -227,6 +236,7 @@ function PaneNode({
               fontWeight={fontWeight}
               fontWeightBold={fontWeightBold}
               useWorker={useWorker}
+              parserPool={parserPool}
               onRef={onRef}
               sharedContext={sharedContext}
             />
@@ -252,6 +262,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
       fontWeight,
       fontWeightBold,
       useWorker,
+      parserWorkers,
       className,
       style,
     } = props;
@@ -259,6 +270,8 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
     const terminalsRef = useRef<Map<string, TerminalHandle>>(new Map());
     const sharedContextRef = useRef<SharedWebGLContext | null>(null);
     const [sharedContext, setSharedContext] = useState<SharedWebGLContext | null>(null);
+    const parserPoolRef = useRef<ParserPool | null>(null);
+    const [parserPool, setParserPool] = useState<ParserPool | null>(null);
 
     const handleRef = useCallback((id: string, handle: TerminalHandle | null) => {
       if (handle) {
@@ -346,6 +359,25 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
       }
     }, [theme]);
 
+    // Create and manage the shared parser worker pool.
+    // When useWorker is explicitly false, skip pool creation.
+    useEffect(() => {
+      if (useWorker === false) return;
+      try {
+        const pool = new ParserPool(parserWorkers);
+        parserPoolRef.current = pool;
+        setParserPool(pool);
+        return () => {
+          pool.dispose();
+          parserPoolRef.current = null;
+          setParserPool(null);
+        };
+      } catch {
+        // Pool creation failed — fall back to per-pane workers
+        return;
+      }
+    }, [parserWorkers, useWorker]);
+
     useImperativeHandle(
       ref,
       () => ({
@@ -378,6 +410,7 @@ export const TerminalPane = forwardRef<TerminalPaneHandle, TerminalPaneProps>(
           fontWeight={fontWeight}
           fontWeightBold={fontWeightBold}
           useWorker={useWorker}
+          parserPool={parserPool}
           onRef={handleRef}
           sharedContext={sharedContext}
         />

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -17,7 +17,8 @@
     }
   },
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "test": "vitest run --root ../.. packages/web"
   },
   "dependencies": {
     "@next_term/core": "workspace:*"

--- a/packages/web/src/__tests__/parser-pool.test.ts
+++ b/packages/web/src/__tests__/parser-pool.test.ts
@@ -536,6 +536,39 @@ describe("ParserChannel", () => {
     pool.dispose();
   });
 
+  it("overflow cleans up pool + worker state so the paneId can be re-acquired", () => {
+    // Regression: previously, overflow set `disposed=true` synchronously,
+    // which made the consumer's onError → pool.releaseChannel → dispose()
+    // path bail on the `if (this.disposed) return` check. Worker never got
+    // the dispose message and the pool entry never got cleared, so the next
+    // acquireChannel with the same paneId threw "already in use".
+    const pool = new ParserPool(1);
+    const { grid, altGrid } = makeGrids();
+    const onError = vi.fn(() => {
+      // Simulate what WebTerminal does on worker error: release the channel.
+      pool.releaseChannel("c1");
+    });
+    const channel = pool.acquireChannel("c1", grid, altGrid, makeCursor(), () => {}, onError);
+    channel.start(80, 24, 100);
+
+    // Overflow.
+    channel.write(new Uint8Array(3 * 1024 * 1024));
+    for (let i = 0; i < 15; i++) channel.write(new Uint8Array(1024 * 1024));
+    channel.write(new Uint8Array(2 * 1024 * 1024));
+
+    expect(onError).toHaveBeenCalled();
+    // Worker was told about the dispose (not skipped).
+    expect(createdWorkers[0].disposeCalls().some((m) => m.channelId === "c1")).toBe(true);
+
+    // Most important: the channelId can be re-acquired without throwing.
+    expect(() => {
+      const fresh = pool.acquireChannel("c1", grid, altGrid, makeCursor(), () => {});
+      fresh.start(80, 24, 100);
+    }).not.toThrow();
+
+    pool.dispose();
+  });
+
   it("releaseChannel sends a scoped dispose (does NOT terminate the worker)", () => {
     const pool = new ParserPool(1);
     const { grid, altGrid } = makeGrids();

--- a/packages/web/src/__tests__/parser-pool.test.ts
+++ b/packages/web/src/__tests__/parser-pool.test.ts
@@ -267,6 +267,105 @@ describe("ParserPool", () => {
     pool.dispose();
   });
 
+  it("acquireChannel throws on duplicate channelId", () => {
+    const pool = new ParserPool(1);
+    const { grid, altGrid } = makeGrids();
+    pool.acquireChannel("a", grid, altGrid, makeCursor(), () => {});
+    expect(() => pool.acquireChannel("a", grid, altGrid, makeCursor(), () => {})).toThrow(
+      /already in use/,
+    );
+    pool.dispose();
+  });
+
+  it("decrements worker pending bytes even for flushes on released channels", () => {
+    // Regression: previously, releasing a channel with bytes in flight left
+    // those bytes in workerPendingBytes forever. When enough flushes were
+    // dropped (because their channel was gone), the worker stayed paused
+    // and ALL surviving channels queued writes into an unbounded queue.
+    const pool = new ParserPool(1);
+    const { grid, altGrid } = makeGrids();
+    const a = pool.acquireChannel("a", grid, altGrid, makeCursor(), () => {});
+    const b = pool.acquireChannel("b", grid, altGrid, makeCursor(), () => {});
+    a.start(80, 24, 100);
+    b.start(80, 24, 100);
+
+    // 'a' sends 3 MB — crosses HIGH_WATERMARK, both pause.
+    a.write(new Uint8Array(3 * 1024 * 1024));
+    expect(a.isPaused).toBe(true);
+    expect(b.isPaused).toBe(true);
+
+    // Release 'a' WITHOUT first draining its pending bytes.
+    pool.releaseChannel("a");
+
+    // The flush for a's 3 MB arrives AFTER release. Even though channel 'a'
+    // is gone, the pool must reconcile the pending bytes or b stays paused.
+    createdWorkers[0].simulateMessage({
+      type: "flush",
+      channelId: "a",
+      cursor: { row: 0, col: 0, visible: true, style: "block" },
+      isAlternate: false,
+      bytesProcessed: 3 * 1024 * 1024,
+      modes: DEFAULT_MODES,
+    });
+
+    // b should now be unpaused — the worker has no in-flight bytes.
+    expect(b.isPaused).toBe(false);
+    pool.dispose();
+  });
+
+  it("worker crash terminates the worker, resets flow control, and unpauses channels", () => {
+    const pool = new ParserPool(2);
+    const { grid, altGrid } = makeGrids();
+    const errorA = vi.fn();
+
+    const a = pool.acquireChannel("a", grid, altGrid, makeCursor(), () => {}, errorA);
+    a.start(80, 24, 100);
+
+    // Saturate worker 0.
+    a.write(new Uint8Array(3 * 1024 * 1024));
+    expect(a.isPaused).toBe(true);
+
+    // Worker 0 crashes.
+    createdWorkers[0].simulateError("OOM");
+
+    // Error forwarded to channel.
+    expect(errorA).toHaveBeenCalled();
+    // Channel is no longer paused so it doesn't keep queueing.
+    expect(a.isPaused).toBe(false);
+    // Dead worker was terminated.
+    expect(createdWorkers[0].terminate).toHaveBeenCalled();
+    pool.dispose();
+  });
+
+  it("tagged generation rejects stale flushes after channelId reuse", () => {
+    // Simulate a real-world reuse: acquire "a", release "a", acquire "a"
+    // again. A late flush from the first lifecycle must NOT reach the
+    // second channel's handler.
+    const pool = new ParserPool(1);
+    const { grid, altGrid } = makeGrids();
+    const flush1 = vi.fn();
+    const flush2 = vi.fn();
+
+    pool.acquireChannel("a", grid, altGrid, makeCursor(), flush1).start(80, 24, 100);
+    pool.releaseChannel("a");
+    pool.acquireChannel("a", grid, altGrid, makeCursor(), flush2).start(80, 24, 100);
+
+    // A stale flush from generation 1 arrives. The new channel is gen 2.
+    createdWorkers[0].simulateMessage({
+      type: "flush",
+      channelId: "a",
+      generation: 1,
+      cursor: { row: 0, col: 0, visible: true, style: "block" },
+      isAlternate: false,
+      bytesProcessed: 5,
+      modes: DEFAULT_MODES,
+    });
+
+    // The new channel (gen 2) is untouched by the stale flush.
+    expect(flush2).not.toHaveBeenCalled();
+    pool.dispose();
+  });
+
   it("throws from acquireChannel when all workers are dead", () => {
     const pool = new ParserPool(1);
     const { grid, altGrid } = makeGrids();

--- a/packages/web/src/__tests__/parser-pool.test.ts
+++ b/packages/web/src/__tests__/parser-pool.test.ts
@@ -323,35 +323,6 @@ describe("ParserChannel", () => {
     pool.dispose();
   });
 
-  it("write() drops data once queued bytes exceed the cap", () => {
-    // With no flushes coming back, once pendingBytes crosses HIGH_WATERMARK
-    // the channel pauses and subsequent writes land in writeQueue. Past the
-    // 16MB queue cap, writes are silently dropped.
-    const pool = new ParserPool(1);
-    const { grid, altGrid } = makeGrids();
-    const channel = pool.acquireChannel("c1", grid, altGrid, makeCursor(), () => {});
-    channel.start(80, 24, 100);
-
-    // 3MB write — crosses the 2MB HIGH_WATERMARK. After this, paused=true.
-    channel.write(new Uint8Array(3 * 1024 * 1024));
-    expect(channel.isPaused).toBe(true);
-
-    // Queue 15MB more (under 16MB cap).
-    for (let i = 0; i < 15; i++) {
-      channel.write(new Uint8Array(1024 * 1024));
-    }
-
-    const writesBefore = createdWorkers[0].writeCalls().length;
-
-    // Now try to queue another 2MB — should be dropped (would exceed cap).
-    channel.write(new Uint8Array(2 * 1024 * 1024));
-
-    // No new write message was sent (still paused, and the queued write was dropped).
-    const writesAfter = createdWorkers[0].writeCalls().length;
-    expect(writesAfter).toBe(writesBefore);
-    pool.dispose();
-  });
-
   it("releaseChannel sends a scoped dispose (does NOT terminate the worker)", () => {
     const pool = new ParserPool(1);
     const { grid, altGrid } = makeGrids();

--- a/packages/web/src/__tests__/parser-pool.test.ts
+++ b/packages/web/src/__tests__/parser-pool.test.ts
@@ -323,6 +323,43 @@ describe("ParserChannel", () => {
     pool.dispose();
   });
 
+  it("pauses ALL channels on a worker once its pending bytes cross HIGH_WATERMARK", () => {
+    // Flow control is per-worker, not per-channel. When one channel on a
+    // worker pushes the worker over HIGH_WATERMARK, every channel on that
+    // worker pauses together (prevents 8× queue inflation).
+    const pool = new ParserPool(1);
+    const { grid, altGrid } = makeGrids();
+    const a = pool.acquireChannel("a", grid, altGrid, makeCursor(), () => {});
+    const b = pool.acquireChannel("b", grid, altGrid, makeCursor(), () => {});
+    a.start(80, 24, 100);
+    b.start(80, 24, 100);
+
+    expect(a.isPaused).toBe(false);
+    expect(b.isPaused).toBe(false);
+
+    // Channel a dumps 3 MB — crosses the 2 MB HIGH_WATERMARK for the worker.
+    a.write(new Uint8Array(3 * 1024 * 1024));
+
+    // Both channels on this worker are now paused — not just the one that sent.
+    expect(a.isPaused).toBe(true);
+    expect(b.isPaused).toBe(true);
+
+    // A flush draining the worker below LOW_WATERMARK unpauses both.
+    createdWorkers[0].simulateMessage({
+      type: "flush",
+      channelId: "a",
+      cursor: { row: 0, col: 0, visible: true, style: "block" },
+      isAlternate: false,
+      bytesProcessed: 3 * 1024 * 1024,
+      modes: DEFAULT_MODES,
+    });
+
+    expect(a.isPaused).toBe(false);
+    expect(b.isPaused).toBe(false);
+
+    pool.dispose();
+  });
+
   it("releaseChannel sends a scoped dispose (does NOT terminate the worker)", () => {
     const pool = new ParserPool(1);
     const { grid, altGrid } = makeGrids();

--- a/packages/web/src/__tests__/parser-pool.test.ts
+++ b/packages/web/src/__tests__/parser-pool.test.ts
@@ -337,6 +337,55 @@ describe("ParserPool", () => {
     pool.dispose();
   });
 
+  it("worker-tagged generation is echoed through init → flush (integration)", () => {
+    // Integration test: no manual generation injection. We read the
+    // generation the pool sent on init, and echo THAT value back on flush —
+    // exactly what the real worker does. This is the test that would have
+    // caught the prior cosmetic fix where the worker never echoed generation.
+    const pool = new ParserPool(1);
+    const { grid, altGrid } = makeGrids();
+    const flushOld = vi.fn();
+    const flushNew = vi.fn();
+
+    const c1 = pool.acquireChannel("a", grid, altGrid, makeCursor(), flushOld);
+    c1.start(80, 24, 100);
+    const gen1 = (createdWorkers[0].initCalls()[0] as { generation?: number }).generation;
+    expect(typeof gen1).toBe("number");
+
+    pool.releaseChannel("a");
+    const c2 = pool.acquireChannel("a", grid, altGrid, makeCursor(), flushNew);
+    c2.start(80, 24, 100);
+    const gen2 = (createdWorkers[0].initCalls()[1] as { generation?: number }).generation;
+    expect(gen2).not.toBe(gen1);
+
+    // Late flush for generation 1 (the prior lifecycle) — must not reach
+    // the new channel even though the channelId matches.
+    createdWorkers[0].simulateMessage({
+      type: "flush",
+      channelId: "a",
+      generation: gen1,
+      cursor: { row: 0, col: 0, visible: true, style: "block" },
+      isAlternate: false,
+      bytesProcessed: 5,
+      modes: DEFAULT_MODES,
+    });
+    expect(flushNew).not.toHaveBeenCalled();
+
+    // Flush with current generation is delivered.
+    createdWorkers[0].simulateMessage({
+      type: "flush",
+      channelId: "a",
+      generation: gen2,
+      cursor: { row: 0, col: 0, visible: true, style: "block" },
+      isAlternate: false,
+      bytesProcessed: 5,
+      modes: DEFAULT_MODES,
+    });
+    expect(flushNew).toHaveBeenCalledTimes(1);
+
+    pool.dispose();
+  });
+
   it("tagged generation rejects stale flushes after channelId reuse", () => {
     // Simulate a real-world reuse: acquire "a", release "a", acquire "a"
     // again. A late flush from the first lifecycle must NOT reach the
@@ -455,6 +504,34 @@ describe("ParserChannel", () => {
 
     expect(a.isPaused).toBe(false);
     expect(b.isPaused).toBe(false);
+
+    pool.dispose();
+  });
+
+  it("writeQueue overflow invokes onError (no silent byte drop)", () => {
+    // With no flushes coming back, once pendingBytes crosses HIGH_WATERMARK
+    // the channel pauses and subsequent writes land in writeQueue. Past the
+    // 16 MB cap, the channel surfaces an error and disposes itself — the
+    // consumer (WebTerminal) then falls back to main-thread parsing.
+    // Silently dropping bytes mid-escape corrupts the VT parser, so the
+    // cap must surface rather than drop.
+    const pool = new ParserPool(1);
+    const { grid, altGrid } = makeGrids();
+    const onError = vi.fn();
+    const channel = pool.acquireChannel("c1", grid, altGrid, makeCursor(), () => {}, onError);
+    channel.start(80, 24, 100);
+
+    // 3 MB crosses the 2 MB HIGH_WATERMARK — channel is now paused.
+    channel.write(new Uint8Array(3 * 1024 * 1024));
+    expect(channel.isPaused).toBe(true);
+
+    // Queue 15 MB more (total queued 15 MB, under the 16 MB cap).
+    for (let i = 0; i < 15; i++) channel.write(new Uint8Array(1024 * 1024));
+    expect(onError).not.toHaveBeenCalled();
+
+    // The next 2 MB write would push the queue over 16 MB — surface error.
+    channel.write(new Uint8Array(2 * 1024 * 1024));
+    expect(onError).toHaveBeenCalledWith(expect.stringContaining("queue exceeded"));
 
     pool.dispose();
   });

--- a/packages/web/src/__tests__/parser-pool.test.ts
+++ b/packages/web/src/__tests__/parser-pool.test.ts
@@ -1,0 +1,367 @@
+import type { CursorState } from "@next_term/core";
+import { CellGrid } from "@next_term/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ParserPool } from "../parser-pool.js";
+import type { FlushMessage } from "../parser-worker.js";
+
+const DEFAULT_MODES: FlushMessage["modes"] = {
+  applicationCursorKeys: false,
+  bracketedPasteMode: false,
+  mouseProtocol: "none",
+  mouseEncoding: "default",
+  sendFocusEvents: false,
+  kittyFlags: 0,
+  syncedOutput: false,
+};
+
+// ---------------------------------------------------------------------------
+// Mock Worker
+// ---------------------------------------------------------------------------
+
+interface Mock {
+  postMessage: ReturnType<typeof vi.fn>;
+  terminate: ReturnType<typeof vi.fn>;
+  simulateMessage(data: unknown): void;
+  simulateError(message: string): void;
+  initCalls(): { channelId?: string }[];
+  writeCalls(): { channelId?: string; data?: ArrayBuffer }[];
+  disposeCalls(): { channelId?: string }[];
+}
+
+const createdWorkers: Mock[] = [];
+
+function makeMockWorker(): Mock {
+  const listeners = new Map<string, Set<(event: Event) => void>>();
+  const postMessage = vi.fn();
+  const terminate = vi.fn();
+  const mock: Mock = {
+    postMessage,
+    terminate,
+    simulateMessage(data) {
+      for (const h of listeners.get("message") ?? []) h({ data } as MessageEvent);
+    },
+    simulateError(message) {
+      for (const h of listeners.get("error") ?? []) h({ message } as ErrorEvent);
+    },
+    initCalls() {
+      return postMessage.mock.calls.map((c) => c[0]).filter((m) => m?.type === "init");
+    },
+    writeCalls() {
+      return postMessage.mock.calls.map((c) => c[0]).filter((m) => m?.type === "write");
+    },
+    disposeCalls() {
+      return postMessage.mock.calls.map((c) => c[0]).filter((m) => m?.type === "dispose");
+    },
+  };
+
+  // Attach listener tracking to the returned proxy object that ParserPool sees.
+  (
+    mock as Mock & { addEventListener: (t: string, h: (e: Event) => void) => void }
+  ).addEventListener = (type, handler) => {
+    if (!listeners.has(type)) listeners.set(type, new Set());
+    listeners.get(type)?.add(handler);
+  };
+  (
+    mock as Mock & { removeEventListener: (t: string, h: (e: Event) => void) => void }
+  ).removeEventListener = (type, handler) => {
+    listeners.get(type)?.delete(handler);
+  };
+
+  return mock;
+}
+
+vi.stubGlobal("Worker", function MockWorkerCtor() {
+  const m = makeMockWorker();
+  createdWorkers.push(m);
+  return m;
+} as unknown as typeof Worker);
+
+vi.stubGlobal(
+  "URL",
+  class {
+    href: string;
+    constructor(path: string, base?: string | URL) {
+      this.href = `${base ?? ""}${path}`;
+    }
+    toString(): string {
+      return this.href;
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCursor(): CursorState {
+  return { row: 0, col: 0, visible: true, style: "block", wrapPending: false };
+}
+
+function makeGrids() {
+  return { grid: new CellGrid(80, 24), altGrid: new CellGrid(80, 24) };
+}
+
+beforeEach(() => {
+  createdWorkers.length = 0;
+});
+
+afterEach(() => {
+  createdWorkers.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ParserPool", () => {
+  it("spawns the requested number of workers", () => {
+    const pool = new ParserPool(4);
+    expect(createdWorkers.length).toBe(4);
+    expect(pool.workerCount).toBe(4);
+    pool.dispose();
+  });
+
+  it("clamps workerCount to at least 1", () => {
+    const pool = new ParserPool(0);
+    expect(createdWorkers.length).toBe(1);
+    pool.dispose();
+  });
+
+  it("acquireChannel + start assigns channels round-robin to least-loaded worker", () => {
+    const pool = new ParserPool(2);
+    const { grid, altGrid } = makeGrids();
+
+    pool.acquireChannel("a", grid, altGrid, makeCursor(), () => {}).start(80, 24, 100);
+    pool.acquireChannel("b", grid, altGrid, makeCursor(), () => {}).start(80, 24, 100);
+    pool.acquireChannel("c", grid, altGrid, makeCursor(), () => {}).start(80, 24, 100);
+
+    const w0Ids = createdWorkers[0].initCalls().map((m) => m.channelId);
+    const w1Ids = createdWorkers[1].initCalls().map((m) => m.channelId);
+
+    expect(w0Ids).toEqual(["a", "c"]);
+    expect(w1Ids).toEqual(["b"]);
+
+    pool.dispose();
+  });
+
+  it("releaseChannel frees the worker for reuse by next acquire", () => {
+    const pool = new ParserPool(2);
+    const { grid, altGrid } = makeGrids();
+
+    pool.acquireChannel("a", grid, altGrid, makeCursor(), () => {}).start(80, 24, 100);
+    pool.acquireChannel("b", grid, altGrid, makeCursor(), () => {}).start(80, 24, 100);
+    pool.releaseChannel("a");
+    pool.acquireChannel("c", grid, altGrid, makeCursor(), () => {}).start(80, 24, 100);
+
+    // c should land on worker 0 (it has 0 channels after releasing 'a')
+    const w0Ids = createdWorkers[0].initCalls().map((m) => m.channelId);
+    expect(w0Ids).toContain("c");
+
+    pool.dispose();
+  });
+
+  it("routes flush messages to the correct channel by channelId", () => {
+    const pool = new ParserPool(2);
+    const { grid, altGrid } = makeGrids();
+    const flushA = vi.fn();
+    const flushB = vi.fn();
+
+    pool.acquireChannel("a", grid, altGrid, makeCursor(), flushA).start(80, 24, 100);
+    pool.acquireChannel("b", grid, altGrid, makeCursor(), flushB).start(80, 24, 100);
+
+    createdWorkers[1].simulateMessage({
+      type: "flush",
+      channelId: "b",
+      cursor: { row: 0, col: 0, visible: true, style: "block" },
+      isAlternate: false,
+      bytesProcessed: 5,
+      modes: DEFAULT_MODES,
+    });
+
+    expect(flushB).toHaveBeenCalled();
+    expect(flushA).not.toHaveBeenCalled();
+
+    pool.dispose();
+  });
+
+  it("drops stale flushes from the previous worker after channelId reuse", () => {
+    // Scenario: channel "a" acquired on worker 0, released, re-acquired on
+    // worker 1. A late flush from worker 0 must not be applied to the new
+    // channel on worker 1.
+    const pool = new ParserPool(2);
+    const { grid, altGrid } = makeGrids();
+    const flushA1 = vi.fn();
+    const flushA2 = vi.fn();
+
+    // Fill worker 0 so next acquire lands on worker 0 first, then fill both.
+    pool.acquireChannel("a", grid, altGrid, makeCursor(), flushA1).start(80, 24, 100);
+    // Release, then acquire a "filler" to shift balance so new "a" lands on worker 1.
+    pool.releaseChannel("a");
+    pool.acquireChannel("filler", grid, altGrid, makeCursor(), () => {}).start(80, 24, 100);
+    // Now acquire "a" again — should go to worker 0 (count 0) or worker 1 (count 1);
+    // either way, we just need to know which one.
+    pool.acquireChannel("a", grid, altGrid, makeCursor(), flushA2).start(80, 24, 100);
+
+    // Determine which worker the new "a" is on by inspecting init calls.
+    const newAOnWorker = createdWorkers[0]
+      .initCalls()
+      .some(
+        (m) =>
+          m.channelId === "a" &&
+          createdWorkers[0].initCalls().filter((x) => x.channelId === "a").length >= 2,
+      )
+      ? 0
+      : 1;
+    const staleWorker = newAOnWorker === 0 ? 1 : 0;
+
+    // Simulate a stale flush arriving from the OTHER worker.
+    createdWorkers[staleWorker].simulateMessage({
+      type: "flush",
+      channelId: "a",
+      cursor: { row: 0, col: 0, visible: true, style: "block" },
+      isAlternate: false,
+      bytesProcessed: 5,
+      modes: DEFAULT_MODES,
+    });
+
+    // Stale flush must be dropped — flushA2 (the new channel) was NOT called.
+    expect(flushA2).not.toHaveBeenCalled();
+    pool.dispose();
+  });
+
+  it("drops late flushes for released channels", () => {
+    const pool = new ParserPool(1);
+    const { grid, altGrid } = makeGrids();
+    const flushA = vi.fn();
+
+    pool.acquireChannel("a", grid, altGrid, makeCursor(), flushA).start(80, 24, 100);
+    pool.releaseChannel("a");
+
+    createdWorkers[0].simulateMessage({
+      type: "flush",
+      channelId: "a",
+      cursor: { row: 0, col: 0, visible: true, style: "block" },
+      isAlternate: false,
+      bytesProcessed: 5,
+      modes: DEFAULT_MODES,
+    });
+
+    expect(flushA).not.toHaveBeenCalled();
+    pool.dispose();
+  });
+
+  it("marks crashed workers dead and skips them on next assignment", () => {
+    const pool = new ParserPool(2);
+    const { grid, altGrid } = makeGrids();
+    const errorA = vi.fn();
+
+    pool.acquireChannel("a", grid, altGrid, makeCursor(), () => {}, errorA).start(80, 24, 100);
+    createdWorkers[0].simulateError("boom");
+    expect(errorA).toHaveBeenCalled();
+
+    // Worker 0 is dead; next acquire must land on worker 1.
+    pool.acquireChannel("b", grid, altGrid, makeCursor(), () => {}).start(80, 24, 100);
+
+    const w1Ids = createdWorkers[1].initCalls().map((m) => m.channelId);
+    expect(w1Ids).toContain("b");
+    pool.dispose();
+  });
+
+  it("throws from acquireChannel when all workers are dead", () => {
+    const pool = new ParserPool(1);
+    const { grid, altGrid } = makeGrids();
+
+    createdWorkers[0].simulateError("boom");
+
+    expect(() => pool.acquireChannel("a", grid, altGrid, makeCursor(), () => {})).toThrow(
+      /no live workers/,
+    );
+
+    pool.dispose();
+  });
+
+  it("dispose() terminates all workers", () => {
+    const pool = new ParserPool(3);
+    pool.dispose();
+    for (const w of createdWorkers) {
+      expect(w.terminate).toHaveBeenCalled();
+    }
+  });
+
+  it("dispose() prevents further acquireChannel calls", () => {
+    const pool = new ParserPool(2);
+    pool.dispose();
+    const { grid, altGrid } = makeGrids();
+    expect(() => pool.acquireChannel("a", grid, altGrid, makeCursor(), () => {})).toThrow(
+      /disposed/,
+    );
+  });
+});
+
+describe("ParserChannel", () => {
+  it("start() sends init tagged with channelId", () => {
+    const pool = new ParserPool(1);
+    const { grid, altGrid } = makeGrids();
+    const channel = pool.acquireChannel("c1", grid, altGrid, makeCursor(), () => {});
+    channel.start(80, 24, 100);
+
+    const init = createdWorkers[0].initCalls()[0];
+    expect(init).toMatchObject({ type: "init", channelId: "c1", cols: 80, rows: 24 });
+    pool.dispose();
+  });
+
+  it("write() sends message tagged with channelId", () => {
+    const pool = new ParserPool(1);
+    const { grid, altGrid } = makeGrids();
+    const channel = pool.acquireChannel("c1", grid, altGrid, makeCursor(), () => {});
+    channel.start(80, 24, 100);
+    channel.write(new Uint8Array([1, 2, 3]));
+
+    const writes = createdWorkers[0].writeCalls();
+    expect(writes).toHaveLength(1);
+    expect(writes[0].channelId).toBe("c1");
+    pool.dispose();
+  });
+
+  it("write() drops data once queued bytes exceed the cap", () => {
+    // With no flushes coming back, once pendingBytes crosses HIGH_WATERMARK
+    // the channel pauses and subsequent writes land in writeQueue. Past the
+    // 16MB queue cap, writes are silently dropped.
+    const pool = new ParserPool(1);
+    const { grid, altGrid } = makeGrids();
+    const channel = pool.acquireChannel("c1", grid, altGrid, makeCursor(), () => {});
+    channel.start(80, 24, 100);
+
+    // 3MB write — crosses the 2MB HIGH_WATERMARK. After this, paused=true.
+    channel.write(new Uint8Array(3 * 1024 * 1024));
+    expect(channel.isPaused).toBe(true);
+
+    // Queue 15MB more (under 16MB cap).
+    for (let i = 0; i < 15; i++) {
+      channel.write(new Uint8Array(1024 * 1024));
+    }
+
+    const writesBefore = createdWorkers[0].writeCalls().length;
+
+    // Now try to queue another 2MB — should be dropped (would exceed cap).
+    channel.write(new Uint8Array(2 * 1024 * 1024));
+
+    // No new write message was sent (still paused, and the queued write was dropped).
+    const writesAfter = createdWorkers[0].writeCalls().length;
+    expect(writesAfter).toBe(writesBefore);
+    pool.dispose();
+  });
+
+  it("releaseChannel sends a scoped dispose (does NOT terminate the worker)", () => {
+    const pool = new ParserPool(1);
+    const { grid, altGrid } = makeGrids();
+    pool.acquireChannel("c1", grid, altGrid, makeCursor(), () => {}).start(80, 24, 100);
+    pool.releaseChannel("c1");
+
+    const disposes = createdWorkers[0].disposeCalls();
+    expect(disposes).toHaveLength(1);
+    expect(disposes[0].channelId).toBe("c1");
+    expect(createdWorkers[0].terminate).not.toHaveBeenCalled();
+    pool.dispose();
+  });
+});

--- a/packages/web/src/__tests__/parser-worker.test.ts
+++ b/packages/web/src/__tests__/parser-worker.test.ts
@@ -311,21 +311,18 @@ describe("multi-channel mode", () => {
     return undefined;
   }
 
-  it("init with channelId creates an isolated parser per channel", async () => {
+  it("init with channelId creates an isolated parser per channel", () => {
     sent.length = 0;
     dispatch({ type: "init", channelId: "a", cols: 80, rows: 24, scrollback: 100 });
     dispatch({ type: "init", channelId: "b", cols: 80, rows: 24, scrollback: 100 });
 
     dispatch({ type: "write", channelId: "a", data: enc("A") });
-    dispatch({ type: "write", channelId: "b", data: enc("") });
-    // Round-robin drain is deferred to a microtask — await it.
-    await Promise.resolve();
-
     const flushA = lastFlushFor("a");
     expect(flushA?.channelId).toBe("a");
     expect(flushA?.cursor.col).toBe(1);
 
     // Channel 'b' cursor was not moved by the write to 'a'.
+    dispatch({ type: "write", channelId: "b", data: enc("") });
     const flushB = lastFlushFor("b");
     expect(flushB?.channelId).toBe("b");
     expect(flushB?.cursor.col).toBe(0);
@@ -339,33 +336,7 @@ describe("multi-channel mode", () => {
     expect(msg.channelId).toBe("ghost");
   });
 
-  it("drains channel writes round-robin (no head-of-line blocking)", async () => {
-    sent.length = 0;
-    dispatch({ type: "init", channelId: "a", cols: 80, rows: 24, scrollback: 100 });
-    dispatch({ type: "init", channelId: "b", cols: 80, rows: 24, scrollback: 100 });
-
-    // Burst for A before B queues its single write.
-    dispatch({ type: "write", channelId: "a", data: enc("A1") });
-    dispatch({ type: "write", channelId: "a", data: enc("A2") });
-    dispatch({ type: "write", channelId: "a", data: enc("A3") });
-    dispatch({ type: "write", channelId: "b", data: enc("B1") });
-
-    await Promise.resolve();
-
-    // Extract the ORDER of channel flushes produced by the drain.
-    const flushOrder = sent
-      .map((s) => s.data as FlushMessage)
-      .filter((m) => m?.type === "flush")
-      .map((m) => m.channelId);
-
-    // FIFO would give: [a, a, a, b] — b waits for all 3 of a.
-    // Round-robin gives: [a, b, a, a] — b gets processed in round 1.
-    expect(flushOrder[1]).toBe("b");
-    // All 4 writes produced flushes.
-    expect(flushOrder).toHaveLength(4);
-  });
-
-  it("dispose with channelId removes that channel but does NOT close the worker", async () => {
+  it("dispose with channelId removes that channel but does NOT close the worker", () => {
     const closeSpy = vi.fn();
     vi.stubGlobal("close", closeSpy);
 
@@ -378,11 +349,10 @@ describe("multi-channel mode", () => {
     // c2 still works
     sent.length = 0;
     dispatch({ type: "write", channelId: "c2", data: enc("X") });
-    await Promise.resolve();
     const flush = lastFlushFor("c2");
     expect(flush?.channelId).toBe("c2");
 
-    // c1 is gone — write to it posts an error synchronously (no drain needed)
+    // c1 is gone
     sent.length = 0;
     dispatch({ type: "write", channelId: "c1", data: enc("X") });
     const err = lastSent() as ErrorMessage;

--- a/packages/web/src/__tests__/parser-worker.test.ts
+++ b/packages/web/src/__tests__/parser-worker.test.ts
@@ -359,4 +359,54 @@ describe("multi-channel mode", () => {
     expect(err.type).toBe("error");
     expect(err.channelId).toBe("c1");
   });
+
+  it("echoes init generation onto every outbound flush for that channel", () => {
+    sent.length = 0;
+    dispatch({
+      type: "init",
+      channelId: "g1",
+      generation: 7,
+      cols: 80,
+      rows: 24,
+      scrollback: 100,
+    });
+
+    dispatch({ type: "write", channelId: "g1", generation: 7, data: enc("X") });
+    const flush = lastFlushFor("g1");
+    expect(flush).toBeDefined();
+    expect(flush?.generation).toBe(7);
+  });
+
+  it("re-init with a new generation invalidates stale writes", () => {
+    sent.length = 0;
+    dispatch({
+      type: "init",
+      channelId: "g2",
+      generation: 1,
+      cols: 80,
+      rows: 24,
+      scrollback: 100,
+    });
+    // Client re-acquired (new generation). Old writes are now stale.
+    dispatch({
+      type: "init",
+      channelId: "g2",
+      generation: 2,
+      cols: 80,
+      rows: 24,
+      scrollback: 100,
+    });
+
+    sent.length = 0;
+    // A stale write from the OLD generation arrives late — must be dropped.
+    dispatch({ type: "write", channelId: "g2", generation: 1, data: enc("A") });
+    const staleFlush = lastFlushFor("g2");
+    expect(staleFlush).toBeUndefined();
+
+    // A write with the CURRENT generation produces a flush tagged with
+    // the current generation.
+    dispatch({ type: "write", channelId: "g2", generation: 2, data: enc("B") });
+    const currentFlush = lastFlushFor("g2");
+    expect(currentFlush?.generation).toBe(2);
+  });
 });

--- a/packages/web/src/__tests__/parser-worker.test.ts
+++ b/packages/web/src/__tests__/parser-worker.test.ts
@@ -299,3 +299,64 @@ describe("dispose message", () => {
     expect(() => dispatch({ type: "dispose" })).not.toThrow();
   });
 });
+
+// ─── Multi-channel mode (pool worker) ──────────────────────────────────────
+
+describe("multi-channel mode", () => {
+  function lastFlushFor(channelId: string): FlushMessage | undefined {
+    for (let i = sent.length - 1; i >= 0; i--) {
+      const msg = sent[i].data as FlushMessage;
+      if (msg?.type === "flush" && msg.channelId === channelId) return msg;
+    }
+    return undefined;
+  }
+
+  it("init with channelId creates an isolated parser per channel", () => {
+    sent.length = 0;
+    dispatch({ type: "init", channelId: "a", cols: 80, rows: 24, scrollback: 100 });
+    dispatch({ type: "init", channelId: "b", cols: 80, rows: 24, scrollback: 100 });
+
+    dispatch({ type: "write", channelId: "a", data: enc("A") });
+    const flushA = lastFlushFor("a");
+    expect(flushA?.channelId).toBe("a");
+    expect(flushA?.cursor.col).toBe(1);
+
+    // Channel 'b' cursor was not moved by the write to 'a'.
+    dispatch({ type: "write", channelId: "b", data: enc("") });
+    const flushB = lastFlushFor("b");
+    expect(flushB?.channelId).toBe("b");
+    expect(flushB?.cursor.col).toBe(0);
+  });
+
+  it("write to unknown channelId posts an error tagged with channelId", () => {
+    sent.length = 0;
+    dispatch({ type: "write", channelId: "ghost", data: enc("X") });
+    const msg = lastSent() as ErrorMessage;
+    expect(msg.type).toBe("error");
+    expect(msg.channelId).toBe("ghost");
+  });
+
+  it("dispose with channelId removes that channel but does NOT close the worker", () => {
+    const closeSpy = vi.fn();
+    vi.stubGlobal("close", closeSpy);
+
+    dispatch({ type: "init", channelId: "c1", cols: 80, rows: 24, scrollback: 100 });
+    dispatch({ type: "init", channelId: "c2", cols: 80, rows: 24, scrollback: 100 });
+    dispatch({ type: "dispose", channelId: "c1" });
+
+    expect(closeSpy).not.toHaveBeenCalled();
+
+    // c2 still works
+    sent.length = 0;
+    dispatch({ type: "write", channelId: "c2", data: enc("X") });
+    const flush = lastFlushFor("c2");
+    expect(flush?.channelId).toBe("c2");
+
+    // c1 is gone
+    sent.length = 0;
+    dispatch({ type: "write", channelId: "c1", data: enc("X") });
+    const err = lastSent() as ErrorMessage;
+    expect(err.type).toBe("error");
+    expect(err.channelId).toBe("c1");
+  });
+});

--- a/packages/web/src/__tests__/parser-worker.test.ts
+++ b/packages/web/src/__tests__/parser-worker.test.ts
@@ -311,18 +311,21 @@ describe("multi-channel mode", () => {
     return undefined;
   }
 
-  it("init with channelId creates an isolated parser per channel", () => {
+  it("init with channelId creates an isolated parser per channel", async () => {
     sent.length = 0;
     dispatch({ type: "init", channelId: "a", cols: 80, rows: 24, scrollback: 100 });
     dispatch({ type: "init", channelId: "b", cols: 80, rows: 24, scrollback: 100 });
 
     dispatch({ type: "write", channelId: "a", data: enc("A") });
+    dispatch({ type: "write", channelId: "b", data: enc("") });
+    // Round-robin drain is deferred to a microtask — await it.
+    await Promise.resolve();
+
     const flushA = lastFlushFor("a");
     expect(flushA?.channelId).toBe("a");
     expect(flushA?.cursor.col).toBe(1);
 
     // Channel 'b' cursor was not moved by the write to 'a'.
-    dispatch({ type: "write", channelId: "b", data: enc("") });
     const flushB = lastFlushFor("b");
     expect(flushB?.channelId).toBe("b");
     expect(flushB?.cursor.col).toBe(0);
@@ -336,7 +339,33 @@ describe("multi-channel mode", () => {
     expect(msg.channelId).toBe("ghost");
   });
 
-  it("dispose with channelId removes that channel but does NOT close the worker", () => {
+  it("drains channel writes round-robin (no head-of-line blocking)", async () => {
+    sent.length = 0;
+    dispatch({ type: "init", channelId: "a", cols: 80, rows: 24, scrollback: 100 });
+    dispatch({ type: "init", channelId: "b", cols: 80, rows: 24, scrollback: 100 });
+
+    // Burst for A before B queues its single write.
+    dispatch({ type: "write", channelId: "a", data: enc("A1") });
+    dispatch({ type: "write", channelId: "a", data: enc("A2") });
+    dispatch({ type: "write", channelId: "a", data: enc("A3") });
+    dispatch({ type: "write", channelId: "b", data: enc("B1") });
+
+    await Promise.resolve();
+
+    // Extract the ORDER of channel flushes produced by the drain.
+    const flushOrder = sent
+      .map((s) => s.data as FlushMessage)
+      .filter((m) => m?.type === "flush")
+      .map((m) => m.channelId);
+
+    // FIFO would give: [a, a, a, b] — b waits for all 3 of a.
+    // Round-robin gives: [a, b, a, a] — b gets processed in round 1.
+    expect(flushOrder[1]).toBe("b");
+    // All 4 writes produced flushes.
+    expect(flushOrder).toHaveLength(4);
+  });
+
+  it("dispose with channelId removes that channel but does NOT close the worker", async () => {
     const closeSpy = vi.fn();
     vi.stubGlobal("close", closeSpy);
 
@@ -349,10 +378,11 @@ describe("multi-channel mode", () => {
     // c2 still works
     sent.length = 0;
     dispatch({ type: "write", channelId: "c2", data: enc("X") });
+    await Promise.resolve();
     const flush = lastFlushFor("c2");
     expect(flush?.channelId).toBe("c2");
 
-    // c1 is gone
+    // c1 is gone — write to it posts an error synchronously (no drain needed)
     sent.length = 0;
     dispatch({ type: "write", channelId: "c1", data: enc("X") });
     const err = lastSent() as ErrorMessage;

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -18,6 +18,7 @@ export { WebLinksAddon } from "./addons/web-links.js";
 export { calculateFit } from "./fit.js";
 export type { InputHandlerOptions, SelectionState } from "./input-handler.js";
 export { InputHandler } from "./input-handler.js";
+export { ParserChannel, ParserPool } from "./parser-pool.js";
 export type { RenderBridgeOptions } from "./render-bridge.js";
 export { canUseOffscreenCanvas, RenderBridge } from "./render-bridge.js";
 export type { HighlightRange, IRenderer, RendererOptions } from "./renderer.js";

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -18,7 +18,7 @@ export { WebLinksAddon } from "./addons/web-links.js";
 export { calculateFit } from "./fit.js";
 export type { InputHandlerOptions, SelectionState } from "./input-handler.js";
 export { InputHandler } from "./input-handler.js";
-export { ParserChannel, ParserPool } from "./parser-pool.js";
+export { DEFAULT_PARSER_WORKER_COUNT, ParserChannel, ParserPool } from "./parser-pool.js";
 export type { RenderBridgeOptions } from "./render-bridge.js";
 export { canUseOffscreenCanvas, RenderBridge } from "./render-bridge.js";
 export type { HighlightRange, IRenderer, RendererOptions } from "./renderer.js";

--- a/packages/web/src/parser-pool.ts
+++ b/packages/web/src/parser-pool.ts
@@ -15,6 +15,10 @@ import { CELL_SIZE, type CellGrid, modPositive } from "@next_term/core";
 import type { FlushMessage, OutboundMessage } from "./parser-worker.js";
 import { HIGH_WATERMARK, LOW_WATERMARK, SAB_AVAILABLE } from "./worker-bridge.js";
 
+/** Hard cap on buffered bytes per channel. If the worker is dead or stalled,
+ *  writes exceeding this are dropped to prevent unbounded memory growth. */
+const MAX_QUEUE_BYTES = 16 * 1024 * 1024; // 16 MB
+
 // ---- ParserChannel ----------------------------------------------------------
 
 /**
@@ -32,6 +36,7 @@ export class ParserChannel {
   private pendingBytes = 0;
   private paused = false;
   private writeQueue: Uint8Array[] = [];
+  private queuedBytes = 0;
   private skipFlushCellDataCount = 0;
 
   private disposed = false;
@@ -70,7 +75,13 @@ export class ParserChannel {
     if (this.disposed) return;
 
     if (this.paused) {
+      // Drop data if the queue would exceed the cap — prevents unbounded
+      // memory growth when the worker is slow or dead.
+      if (this.queuedBytes + data.byteLength > MAX_QUEUE_BYTES) {
+        return;
+      }
       this.writeQueue.push(data);
+      this.queuedBytes += data.byteLength;
       return;
     }
 
@@ -89,6 +100,7 @@ export class ParserChannel {
     this.pendingBytes = 0;
     this.paused = false;
     this.writeQueue.length = 0;
+    this.queuedBytes = 0;
 
     const msg: Record<string, unknown> = {
       type: "resize",
@@ -119,6 +131,7 @@ export class ParserChannel {
     this.disposed = true;
     this.postToWorker({ type: "dispose", channelId: this.channelId });
     this.writeQueue.length = 0;
+    this.queuedBytes = 0;
   }
 
   get isPaused(): boolean {
@@ -242,6 +255,7 @@ export class ParserChannel {
     while (this.writeQueue.length > 0 && !this.paused) {
       const next = this.writeQueue.shift();
       if (!next) break;
+      this.queuedBytes -= next.byteLength;
       this.sendWrite(next);
     }
   };
@@ -249,7 +263,7 @@ export class ParserChannel {
 
 // ---- ParserPool -------------------------------------------------------------
 
-const DEFAULT_WORKER_COUNT = Math.min(
+export const DEFAULT_PARSER_WORKER_COUNT = Math.min(
   typeof navigator !== "undefined" ? (navigator.hardwareConcurrency ?? 4) : 4,
   4,
 );
@@ -272,21 +286,37 @@ export class ParserPool {
   private workers: Worker[] = [];
   private channels = new Map<string, { workerIndex: number; channel: ParserChannel }>();
   private workerChannelCounts: number[];
+  /** Workers that have crashed and should not receive new channel assignments. */
+  private deadWorkers = new Set<number>();
   private disposed = false;
 
-  constructor(workerCount: number = DEFAULT_WORKER_COUNT) {
+  constructor(workerCount: number = DEFAULT_PARSER_WORKER_COUNT) {
     const count = Math.max(1, workerCount);
     this.workerChannelCounts = new Array(count).fill(0);
 
-    for (let i = 0; i < count; i++) {
-      const worker = new Worker(new URL("./parser-worker.js", import.meta.url), { type: "module" });
-      worker.addEventListener("message", (event: MessageEvent<OutboundMessage>) => {
-        this.handleWorkerMessage(i, event);
-      });
-      worker.addEventListener("error", (event: ErrorEvent) => {
-        this.handleWorkerError(i, event);
-      });
-      this.workers.push(worker);
+    try {
+      for (let i = 0; i < count; i++) {
+        const worker = new Worker(new URL("./parser-worker.js", import.meta.url), {
+          type: "module",
+        });
+        worker.addEventListener("message", (event: MessageEvent<OutboundMessage>) => {
+          this.handleWorkerMessage(i, event);
+        });
+        worker.addEventListener("error", (event: ErrorEvent) => {
+          this.handleWorkerError(i, event);
+        });
+        this.workers.push(worker);
+      }
+    } catch (err) {
+      // If mid-loop construction fails, terminate any workers already created
+      // so we don't leak them before throwing.
+      for (const w of this.workers) {
+        try {
+          w.terminate();
+        } catch {}
+      }
+      this.workers.length = 0;
+      throw err;
     }
   }
 
@@ -369,21 +399,25 @@ export class ParserPool {
 
   // ---- Internals ------------------------------------------------------------
 
-  /** Pick the worker with the fewest current channels. */
+  /** Pick the live worker with the fewest current channels. */
   private pickWorker(): number {
-    let minIdx = 0;
-    let minCount = this.workerChannelCounts[0];
-    for (let i = 1; i < this.workerChannelCounts.length; i++) {
+    let minIdx = -1;
+    let minCount = Infinity;
+    for (let i = 0; i < this.workerChannelCounts.length; i++) {
+      if (this.deadWorkers.has(i)) continue;
       if (this.workerChannelCounts[i] < minCount) {
         minCount = this.workerChannelCounts[i];
         minIdx = i;
       }
     }
+    if (minIdx === -1) {
+      throw new Error("ParserPool: no live workers available");
+    }
     return minIdx;
   }
 
   /** Demux incoming messages by channelId to the correct ParserChannel. */
-  private handleWorkerMessage(_workerIndex: number, event: MessageEvent<OutboundMessage>): void {
+  private handleWorkerMessage(workerIndex: number, event: MessageEvent<OutboundMessage>): void {
     if (this.disposed) return;
     const msg = event.data;
     const channelId = msg.channelId;
@@ -392,6 +426,10 @@ export class ParserPool {
     const entry = this.channels.get(channelId);
     if (!entry) return; // channel already disposed
 
+    // Guard against channelId reuse: if the channel was released and
+    // re-acquired on a different worker, drop stale flushes from the old one.
+    if (entry.workerIndex !== workerIndex) return;
+
     if (msg.type === "error") {
       entry.channel.handleError(msg.message);
     } else if (msg.type === "flush") {
@@ -399,8 +437,12 @@ export class ParserPool {
     }
   }
 
-  /** Forward worker errors to all channels on that worker. */
+  /** Forward worker errors to all channels on that worker and mark it dead. */
   private handleWorkerError(workerIndex: number, event: ErrorEvent): void {
+    // Mark the worker as dead BEFORE forwarding errors — the error callbacks
+    // may synchronously call releaseChannel, which would otherwise see the
+    // worker as live and leave workerChannelCounts in an inconsistent state.
+    this.deadWorkers.add(workerIndex);
     for (const [, entry] of this.channels) {
       if (entry.workerIndex === workerIndex) {
         entry.channel.handleError(`Worker error: ${event.message}`);

--- a/packages/web/src/parser-pool.ts
+++ b/packages/web/src/parser-pool.ts
@@ -15,10 +15,6 @@ import { CELL_SIZE, type CellGrid, modPositive } from "@next_term/core";
 import type { FlushMessage, OutboundMessage } from "./parser-worker.js";
 import { HIGH_WATERMARK, LOW_WATERMARK, SAB_AVAILABLE } from "./worker-bridge.js";
 
-/** Hard cap on buffered bytes per channel. If the worker is dead or stalled,
- *  writes exceeding this are dropped to prevent unbounded memory growth. */
-const MAX_QUEUE_BYTES = 16 * 1024 * 1024; // 16 MB
-
 // ---- ParserChannel ----------------------------------------------------------
 
 /**
@@ -32,11 +28,10 @@ export class ParserChannel {
   private onFlush: (isAlternate: boolean, modes: FlushMessage["modes"]) => void;
   private onError: ((message: string) => void) | null;
 
-  // Flow control (per-channel, not per-worker)
+  // Flow control (per-channel, not per-worker) — same shape as WorkerBridge
   private pendingBytes = 0;
   private paused = false;
   private writeQueue: Uint8Array[] = [];
-  private queuedBytes = 0;
   private skipFlushCellDataCount = 0;
 
   private disposed = false;
@@ -75,13 +70,7 @@ export class ParserChannel {
     if (this.disposed) return;
 
     if (this.paused) {
-      // Drop data if the queue would exceed the cap — prevents unbounded
-      // memory growth when the worker is slow or dead.
-      if (this.queuedBytes + data.byteLength > MAX_QUEUE_BYTES) {
-        return;
-      }
       this.writeQueue.push(data);
-      this.queuedBytes += data.byteLength;
       return;
     }
 
@@ -100,7 +89,6 @@ export class ParserChannel {
     this.pendingBytes = 0;
     this.paused = false;
     this.writeQueue.length = 0;
-    this.queuedBytes = 0;
 
     const msg: Record<string, unknown> = {
       type: "resize",
@@ -131,7 +119,6 @@ export class ParserChannel {
     this.disposed = true;
     this.postToWorker({ type: "dispose", channelId: this.channelId });
     this.writeQueue.length = 0;
-    this.queuedBytes = 0;
   }
 
   get isPaused(): boolean {
@@ -255,7 +242,6 @@ export class ParserChannel {
     while (this.writeQueue.length > 0 && !this.paused) {
       const next = this.writeQueue.shift();
       if (!next) break;
-      this.queuedBytes -= next.byteLength;
       this.sendWrite(next);
     }
   };

--- a/packages/web/src/parser-pool.ts
+++ b/packages/web/src/parser-pool.ts
@@ -1,0 +1,420 @@
+/**
+ * ParserPool — manages a pool of N parser Web Workers shared across many
+ * terminal panes. Each pane gets a "channel" assigned to one of the workers.
+ *
+ * This avoids the thread oversubscription problem: 32 panes with 4 workers
+ * means 4 postMessage streams instead of 32, dramatically reducing overhead
+ * while still keeping all parsing off the main thread.
+ *
+ * API mirrors SharedWebGLContext: created once at the container level,
+ * channels are acquired/released per pane.
+ */
+
+import type { CursorState } from "@next_term/core";
+import { CELL_SIZE, type CellGrid, modPositive } from "@next_term/core";
+import type { FlushMessage, OutboundMessage } from "./parser-worker.js";
+
+// ---- Flow-control constants (same as WorkerBridge) --------------------------
+
+const HIGH_WATERMARK = 2 * 1024 * 1024; // 2 MB
+const LOW_WATERMARK = 512 * 1024; // 512 KB
+
+// ---- Feature detection ------------------------------------------------------
+
+const SAB_AVAILABLE =
+  typeof SharedArrayBuffer !== "undefined" &&
+  (typeof crossOriginIsolated !== "undefined" ? crossOriginIsolated : true);
+
+// ---- ParserChannel ----------------------------------------------------------
+
+/**
+ * A channel within a shared parser worker. Same public API as WorkerBridge
+ * but routes messages through a shared Worker via channelId.
+ */
+export class ParserChannel {
+  private grid: CellGrid;
+  private altGrid: CellGrid;
+  private cursor: CursorState;
+  private onFlush: (isAlternate: boolean, modes: FlushMessage["modes"]) => void;
+  private onError: ((message: string) => void) | null;
+
+  // Flow control (per-channel, not per-worker)
+  private pendingBytes = 0;
+  private paused = false;
+  private writeQueue: Uint8Array[] = [];
+  private skipFlushCellDataCount = 0;
+
+  private disposed = false;
+
+  constructor(
+    readonly channelId: string,
+    private readonly postToWorker: (msg: unknown, transfer?: Transferable[]) => void,
+    grid: CellGrid,
+    altGrid: CellGrid,
+    cursor: CursorState,
+    onFlush: (isAlternate: boolean, modes: FlushMessage["modes"]) => void,
+    onError?: (message: string) => void,
+  ) {
+    this.grid = grid;
+    this.altGrid = altGrid;
+    this.cursor = cursor;
+    this.onFlush = onFlush;
+    this.onError = onError ?? null;
+  }
+
+  // ---- Public API (mirrors WorkerBridge) ------------------------------------
+
+  start(cols: number, rows: number, scrollback: number): void {
+    if (this.disposed) return;
+    this.postToWorker({
+      type: "init",
+      channelId: this.channelId,
+      cols,
+      rows,
+      scrollback,
+      ...this.getSharedBuffers(),
+    });
+  }
+
+  write(data: Uint8Array): void {
+    if (this.disposed) return;
+
+    if (this.paused) {
+      this.writeQueue.push(data);
+      return;
+    }
+
+    this.sendWrite(data);
+  }
+
+  resize(
+    cols: number,
+    rows: number,
+    scrollback: number,
+    cursorRow?: number,
+    cursorCol?: number,
+  ): void {
+    if (this.disposed) return;
+
+    this.pendingBytes = 0;
+    this.paused = false;
+    this.writeQueue.length = 0;
+
+    const msg: Record<string, unknown> = {
+      type: "resize",
+      channelId: this.channelId,
+      cols,
+      rows,
+      scrollback,
+      cursorRow,
+      cursorCol,
+      ...this.getSharedBuffers(),
+    };
+    const transferables: ArrayBuffer[] = [];
+
+    if (!SAB_AVAILABLE) {
+      this.skipFlushCellDataCount++;
+      const cellCopy = this.grid.data.slice().buffer;
+      const wrapCopy = this.grid.wrapFlags.slice().buffer;
+      msg.reflowedCellData = cellCopy;
+      msg.reflowedWrapFlags = wrapCopy;
+      transferables.push(cellCopy, wrapCopy);
+    }
+
+    this.postToWorker(msg, transferables);
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.postToWorker({ type: "dispose", channelId: this.channelId });
+    this.writeQueue.length = 0;
+  }
+
+  get isPaused(): boolean {
+    return this.paused;
+  }
+
+  get pendingByteCount(): number {
+    return this.pendingBytes;
+  }
+
+  updateGrid(grid: CellGrid, altGrid: CellGrid, cursor: CursorState): void {
+    this.grid = grid;
+    this.altGrid = altGrid;
+    this.cursor = cursor;
+  }
+
+  // ---- Called by ParserPool's demux -----------------------------------------
+
+  /** @internal — called by the pool when a flush arrives for this channel. */
+  handleFlush(msg: FlushMessage): void {
+    if (this.disposed) return;
+
+    this.onFlush(msg.isAlternate, msg.modes);
+
+    this.cursor.row = msg.cursor.row;
+    this.cursor.col = msg.cursor.col;
+    this.cursor.visible = msg.cursor.visible;
+    this.cursor.style = msg.cursor.style as CursorState["style"];
+
+    if (this.skipFlushCellDataCount > 0 && msg.cellData) {
+      this.skipFlushCellDataCount--;
+    } else if (msg.cellData && msg.dirtyRows) {
+      const targetGrid = msg.isAlternate ? this.altGrid : this.grid;
+      const cellView = new Uint32Array(msg.cellData);
+      const dirtyView = new Int32Array(msg.dirtyRows);
+      const cols = targetGrid.cols;
+      const rows = targetGrid.rows;
+
+      const expectedCells = cols * rows * CELL_SIZE;
+      if (cellView.length !== expectedCells || dirtyView.length !== rows) {
+        // Stale flush for a different grid size — update flow control only.
+        this.pendingBytes = Math.max(0, this.pendingBytes - msg.bytesProcessed);
+        if (this.paused && this.pendingBytes < LOW_WATERMARK) {
+          this.paused = false;
+          this.drainQueue();
+        }
+        return;
+      }
+
+      const rowOffset = modPositive(msg.rowOffset ?? 0, rows);
+      targetGrid.rowOffsetData[0] = rowOffset;
+
+      const rowLen = cols * CELL_SIZE;
+      for (let r = 0; r < rows; r++) {
+        if (dirtyView[r] !== 0) {
+          const physRow = modPositive(r + rowOffset, rows);
+          const start = physRow * rowLen;
+          const end = start + rowLen;
+          targetGrid.data.set(cellView.subarray(start, end), start);
+          targetGrid.markDirty(r);
+        }
+      }
+
+      if (msg.wrapFlags) {
+        const wrapView = new Int32Array(msg.wrapFlags);
+        if (wrapView.length === rows) {
+          targetGrid.wrapFlags.set(wrapView);
+        }
+      }
+    }
+
+    this.pendingBytes = Math.max(0, this.pendingBytes - msg.bytesProcessed);
+    if (this.paused && this.pendingBytes < LOW_WATERMARK) {
+      this.paused = false;
+      this.drainQueue();
+    }
+  }
+
+  /** @internal — called by the pool when an error arrives for this channel. */
+  handleError(message: string): void {
+    if (this.disposed) return;
+    this.onError?.(message);
+  }
+
+  // ---- Internals ------------------------------------------------------------
+
+  private getSharedBuffers(): {
+    sharedBuffer?: SharedArrayBuffer;
+    sharedAltBuffer?: SharedArrayBuffer;
+  } {
+    if (SAB_AVAILABLE && this.grid.isShared) {
+      return {
+        sharedBuffer: this.grid.getBuffer() as SharedArrayBuffer,
+        sharedAltBuffer: this.altGrid.getBuffer() as SharedArrayBuffer,
+      };
+    }
+    return {};
+  }
+
+  private sendWrite(data: Uint8Array): void {
+    let buf: ArrayBuffer;
+    if (
+      data.byteOffset === 0 &&
+      data.byteLength === data.buffer.byteLength &&
+      data.buffer instanceof ArrayBuffer
+    ) {
+      buf = data.buffer;
+    } else {
+      buf = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
+    }
+
+    this.pendingBytes += data.byteLength;
+    if (this.pendingBytes >= HIGH_WATERMARK) {
+      this.paused = true;
+    }
+
+    this.postToWorker({ type: "write", channelId: this.channelId, data: buf }, [buf]);
+  }
+
+  private drainQueue = (): void => {
+    while (this.writeQueue.length > 0 && !this.paused) {
+      const next = this.writeQueue.shift();
+      if (!next) break;
+      this.sendWrite(next);
+    }
+  };
+}
+
+// ---- ParserPool -------------------------------------------------------------
+
+const DEFAULT_WORKER_COUNT = Math.min(
+  typeof navigator !== "undefined" ? (navigator.hardwareConcurrency ?? 4) : 4,
+  4,
+);
+
+/**
+ * A pool of N parser Web Workers shared across many terminal panes.
+ *
+ * Usage:
+ * ```ts
+ * const pool = new ParserPool(4);
+ * const channel = pool.acquireChannel("pane-0", grid, altGrid, cursor, onFlush);
+ * channel.start(cols, rows, scrollback);
+ * channel.write(data);
+ * // ...
+ * pool.releaseChannel("pane-0");
+ * pool.dispose();
+ * ```
+ */
+export class ParserPool {
+  private workers: Worker[] = [];
+  private channels = new Map<string, { workerIndex: number; channel: ParserChannel }>();
+  private workerChannelCounts: number[];
+  private disposed = false;
+
+  constructor(workerCount: number = DEFAULT_WORKER_COUNT) {
+    const count = Math.max(1, workerCount);
+    this.workerChannelCounts = new Array(count).fill(0);
+
+    for (let i = 0; i < count; i++) {
+      const worker = new Worker(new URL("./parser-worker.js", import.meta.url), { type: "module" });
+      worker.addEventListener("message", (event: MessageEvent<OutboundMessage>) => {
+        this.handleWorkerMessage(i, event);
+      });
+      worker.addEventListener("error", (event: ErrorEvent) => {
+        this.handleWorkerError(i, event);
+      });
+      this.workers.push(worker);
+    }
+  }
+
+  /** Number of workers in the pool. */
+  get workerCount(): number {
+    return this.workers.length;
+  }
+
+  /**
+   * Acquire a channel for a terminal pane. The channel is assigned to the
+   * worker with the fewest current channels (least-loaded at assignment time).
+   */
+  acquireChannel(
+    channelId: string,
+    grid: CellGrid,
+    altGrid: CellGrid,
+    cursor: CursorState,
+    onFlush: (isAlternate: boolean, modes: FlushMessage["modes"]) => void,
+    onError?: (message: string) => void,
+  ): ParserChannel {
+    if (this.disposed) {
+      throw new Error("ParserPool is disposed");
+    }
+
+    const workerIndex = this.pickWorker();
+    const worker = this.workers[workerIndex];
+
+    const channel = new ParserChannel(
+      channelId,
+      (msg: unknown, transfer?: Transferable[]) => {
+        if (transfer) {
+          worker.postMessage(msg, transfer);
+        } else {
+          worker.postMessage(msg);
+        }
+      },
+      grid,
+      altGrid,
+      cursor,
+      onFlush,
+      onError,
+    );
+
+    this.channels.set(channelId, { workerIndex, channel });
+    this.workerChannelCounts[workerIndex]++;
+
+    return channel;
+  }
+
+  /**
+   * Release a channel. Sends dispose to the worker and cleans up.
+   */
+  releaseChannel(channelId: string): void {
+    const entry = this.channels.get(channelId);
+    if (!entry) return;
+
+    entry.channel.dispose();
+    this.workerChannelCounts[entry.workerIndex]--;
+    this.channels.delete(channelId);
+  }
+
+  /**
+   * Dispose the entire pool — releases all channels and terminates all workers.
+   */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+
+    for (const [, entry] of this.channels) {
+      entry.channel.dispose();
+    }
+    this.channels.clear();
+
+    for (const worker of this.workers) {
+      worker.terminate();
+    }
+    this.workers.length = 0;
+    this.workerChannelCounts.length = 0;
+  }
+
+  // ---- Internals ------------------------------------------------------------
+
+  /** Pick the worker with the fewest current channels. */
+  private pickWorker(): number {
+    let minIdx = 0;
+    let minCount = this.workerChannelCounts[0];
+    for (let i = 1; i < this.workerChannelCounts.length; i++) {
+      if (this.workerChannelCounts[i] < minCount) {
+        minCount = this.workerChannelCounts[i];
+        minIdx = i;
+      }
+    }
+    return minIdx;
+  }
+
+  /** Demux incoming messages by channelId to the correct ParserChannel. */
+  private handleWorkerMessage(_workerIndex: number, event: MessageEvent<OutboundMessage>): void {
+    if (this.disposed) return;
+    const msg = event.data;
+    const channelId = msg.channelId;
+    if (!channelId) return; // no channelId = legacy message, shouldn't happen in pool
+
+    const entry = this.channels.get(channelId);
+    if (!entry) return; // channel already disposed
+
+    if (msg.type === "error") {
+      entry.channel.handleError(msg.message);
+    } else if (msg.type === "flush") {
+      entry.channel.handleFlush(msg);
+    }
+  }
+
+  /** Forward worker errors to all channels on that worker. */
+  private handleWorkerError(workerIndex: number, event: ErrorEvent): void {
+    for (const [, entry] of this.channels) {
+      if (entry.workerIndex === workerIndex) {
+        entry.channel.handleError(`Worker error: ${event.message}`);
+      }
+    }
+  }
+}

--- a/packages/web/src/parser-pool.ts
+++ b/packages/web/src/parser-pool.ts
@@ -33,6 +33,12 @@ import { CELL_SIZE, type CellGrid, modPositive } from "@next_term/core";
 import type { FlushMessage, OutboundMessage } from "./parser-worker.js";
 import { HIGH_WATERMARK, LOW_WATERMARK, SAB_AVAILABLE } from "./worker-bridge.js";
 
+/** Hard cap on per-channel writeQueue memory when the worker is stalled.
+ *  Exceeding this invokes onError so the consumer can fall back to
+ *  main-thread parsing rather than silently dropping bytes (which would
+ *  corrupt the VT parser mid-escape-sequence). */
+const MAX_QUEUE_BYTES = 16 * 1024 * 1024; // 16 MB
+
 // ---- ParserChannel ----------------------------------------------------------
 
 /**
@@ -97,6 +103,19 @@ export class ParserChannel {
     if (this.disposed) return;
 
     if (this.poolPaused) {
+      // Never silently drop bytes mid-stream — dropping inside an escape
+      // sequence corrupts the parser for the remainder of the session.
+      // Instead, surface the overflow so the consumer (WebTerminal) can
+      // fall back to main-thread parsing.
+      if (this.queuedBytes + data.byteLength > MAX_QUEUE_BYTES) {
+        this.disposed = true;
+        this.writeQueue.length = 0;
+        this.queuedBytes = 0;
+        this.onError?.(
+          `ParserChannel "${this.channelId}" queue exceeded ${MAX_QUEUE_BYTES} bytes — worker stalled, falling back`,
+        );
+        return;
+      }
       this.writeQueue.push(data);
       this.queuedBytes += data.byteLength;
       return;

--- a/packages/web/src/parser-pool.ts
+++ b/packages/web/src/parser-pool.ts
@@ -13,17 +13,7 @@
 import type { CursorState } from "@next_term/core";
 import { CELL_SIZE, type CellGrid, modPositive } from "@next_term/core";
 import type { FlushMessage, OutboundMessage } from "./parser-worker.js";
-
-// ---- Flow-control constants (same as WorkerBridge) --------------------------
-
-const HIGH_WATERMARK = 2 * 1024 * 1024; // 2 MB
-const LOW_WATERMARK = 512 * 1024; // 512 KB
-
-// ---- Feature detection ------------------------------------------------------
-
-const SAB_AVAILABLE =
-  typeof SharedArrayBuffer !== "undefined" &&
-  (typeof crossOriginIsolated !== "undefined" ? crossOriginIsolated : true);
+import { HIGH_WATERMARK, LOW_WATERMARK, SAB_AVAILABLE } from "./worker-bridge.js";
 
 // ---- ParserChannel ----------------------------------------------------------
 

--- a/packages/web/src/parser-pool.ts
+++ b/packages/web/src/parser-pool.ts
@@ -8,6 +8,13 @@
  *
  * API mirrors SharedWebGLContext: created once at the container level,
  * channels are acquired/released per pane.
+ *
+ * Flow control is per-WORKER (not per-channel) so that the HIGH_WATERMARK
+ * budget scales with worker capacity, not channel count. All channels on
+ * a saturated worker pause together until that worker drains below
+ * LOW_WATERMARK. This prevents the 8× queue inflation that per-channel
+ * watermarks would otherwise cause (8 channels × 2 MB = 16 MB of in-flight
+ * data sitting in one worker's postMessage queue).
  */
 
 import type { CursorState } from "@next_term/core";
@@ -20,6 +27,8 @@ import { HIGH_WATERMARK, LOW_WATERMARK, SAB_AVAILABLE } from "./worker-bridge.js
 /**
  * A channel within a shared parser worker. Same public API as WorkerBridge
  * but routes messages through a shared Worker via channelId.
+ *
+ * Flow control is delegated to the owning ParserPool — see class-level comment.
  */
 export class ParserChannel {
   private grid: CellGrid;
@@ -28,9 +37,8 @@ export class ParserChannel {
   private onFlush: (isAlternate: boolean, modes: FlushMessage["modes"]) => void;
   private onError: ((message: string) => void) | null;
 
-  // Flow control (per-channel, not per-worker) — same shape as WorkerBridge
-  private pendingBytes = 0;
-  private paused = false;
+  // Local state. Pause signal comes from the pool (per-worker saturation).
+  private poolPaused = false;
   private writeQueue: Uint8Array[] = [];
   private skipFlushCellDataCount = 0;
 
@@ -38,7 +46,16 @@ export class ParserChannel {
 
   constructor(
     readonly channelId: string,
-    private readonly postToWorker: (msg: unknown, transfer?: Transferable[]) => void,
+    /** @internal — pool callback used by ParserChannel to send writes */
+    private readonly poolSendWrite: (
+      channelId: string,
+      buf: ArrayBuffer,
+      byteLength: number,
+    ) => void,
+    /** @internal — pool callback used by ParserChannel to post non-write messages */
+    private readonly poolPost: (msg: unknown, transfer?: Transferable[]) => void,
+    /** @internal — pool callback used by ParserChannel on flush */
+    private readonly poolOnFlushProcessed: (bytesProcessed: number) => void,
     grid: CellGrid,
     altGrid: CellGrid,
     cursor: CursorState,
@@ -56,7 +73,7 @@ export class ParserChannel {
 
   start(cols: number, rows: number, scrollback: number): void {
     if (this.disposed) return;
-    this.postToWorker({
+    this.poolPost({
       type: "init",
       channelId: this.channelId,
       cols,
@@ -69,7 +86,7 @@ export class ParserChannel {
   write(data: Uint8Array): void {
     if (this.disposed) return;
 
-    if (this.paused) {
+    if (this.poolPaused) {
       this.writeQueue.push(data);
       return;
     }
@@ -86,8 +103,6 @@ export class ParserChannel {
   ): void {
     if (this.disposed) return;
 
-    this.pendingBytes = 0;
-    this.paused = false;
     this.writeQueue.length = 0;
 
     const msg: Record<string, unknown> = {
@@ -111,22 +126,18 @@ export class ParserChannel {
       transferables.push(cellCopy, wrapCopy);
     }
 
-    this.postToWorker(msg, transferables);
+    this.poolPost(msg, transferables);
   }
 
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
-    this.postToWorker({ type: "dispose", channelId: this.channelId });
+    this.poolPost({ type: "dispose", channelId: this.channelId });
     this.writeQueue.length = 0;
   }
 
   get isPaused(): boolean {
-    return this.paused;
-  }
-
-  get pendingByteCount(): number {
-    return this.pendingBytes;
+    return this.poolPaused;
   }
 
   updateGrid(grid: CellGrid, altGrid: CellGrid, cursor: CursorState): void {
@@ -135,7 +146,23 @@ export class ParserChannel {
     this.cursor = cursor;
   }
 
-  // ---- Called by ParserPool's demux -----------------------------------------
+  // ---- Called by ParserPool's demux / flow control -------------------------
+
+  /** @internal — called by the pool when the worker becomes saturated or drains. */
+  setPoolPaused(paused: boolean): void {
+    if (this.disposed) return;
+    this.poolPaused = paused;
+  }
+
+  /** @internal — drain queued writes when pool unpauses this channel's worker. */
+  drainQueue(): void {
+    if (this.disposed) return;
+    while (this.writeQueue.length > 0 && !this.poolPaused) {
+      const next = this.writeQueue.shift();
+      if (!next) break;
+      this.sendWrite(next);
+    }
+  }
 
   /** @internal — called by the pool when a flush arrives for this channel. */
   handleFlush(msg: FlushMessage): void {
@@ -159,12 +186,9 @@ export class ParserChannel {
 
       const expectedCells = cols * rows * CELL_SIZE;
       if (cellView.length !== expectedCells || dirtyView.length !== rows) {
-        // Stale flush for a different grid size — update flow control only.
-        this.pendingBytes = Math.max(0, this.pendingBytes - msg.bytesProcessed);
-        if (this.paused && this.pendingBytes < LOW_WATERMARK) {
-          this.paused = false;
-          this.drainQueue();
-        }
+        // Stale flush for a different grid size — still tell the pool the
+        // bytes were processed so its worker counter stays accurate.
+        this.poolOnFlushProcessed(msg.bytesProcessed);
         return;
       }
 
@@ -190,11 +214,7 @@ export class ParserChannel {
       }
     }
 
-    this.pendingBytes = Math.max(0, this.pendingBytes - msg.bytesProcessed);
-    if (this.paused && this.pendingBytes < LOW_WATERMARK) {
-      this.paused = false;
-      this.drainQueue();
-    }
+    this.poolOnFlushProcessed(msg.bytesProcessed);
   }
 
   /** @internal — called by the pool when an error arrives for this channel. */
@@ -230,21 +250,8 @@ export class ParserChannel {
       buf = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
     }
 
-    this.pendingBytes += data.byteLength;
-    if (this.pendingBytes >= HIGH_WATERMARK) {
-      this.paused = true;
-    }
-
-    this.postToWorker({ type: "write", channelId: this.channelId, data: buf }, [buf]);
+    this.poolSendWrite(this.channelId, buf, data.byteLength);
   }
-
-  private drainQueue = (): void => {
-    while (this.writeQueue.length > 0 && !this.paused) {
-      const next = this.writeQueue.shift();
-      if (!next) break;
-      this.sendWrite(next);
-    }
-  };
 }
 
 // ---- ParserPool -------------------------------------------------------------
@@ -272,6 +279,9 @@ export class ParserPool {
   private workers: Worker[] = [];
   private channels = new Map<string, { workerIndex: number; channel: ParserChannel }>();
   private workerChannelCounts: number[];
+  /** Per-worker flow control — pendingBytes is shared across all channels. */
+  private workerPendingBytes: number[];
+  private workerPaused: boolean[];
   /** Workers that have crashed and should not receive new channel assignments. */
   private deadWorkers = new Set<number>();
   private disposed = false;
@@ -279,6 +289,8 @@ export class ParserPool {
   constructor(workerCount: number = DEFAULT_PARSER_WORKER_COUNT) {
     const count = Math.max(1, workerCount);
     this.workerChannelCounts = new Array(count).fill(0);
+    this.workerPendingBytes = new Array(count).fill(0);
+    this.workerPaused = new Array(count).fill(false);
 
     try {
       for (let i = 0; i < count; i++) {
@@ -332,13 +344,15 @@ export class ParserPool {
 
     const channel = new ParserChannel(
       channelId,
-      (msg: unknown, transfer?: Transferable[]) => {
+      (cid, buf, byteLength) => this.sendWriteFromChannel(workerIndex, cid, buf, byteLength),
+      (msg, transfer) => {
         if (transfer) {
           worker.postMessage(msg, transfer);
         } else {
           worker.postMessage(msg);
         }
       },
+      (bytesProcessed) => this.onFlushProcessed(workerIndex, bytesProcessed),
       grid,
       altGrid,
       cursor,
@@ -348,6 +362,12 @@ export class ParserPool {
 
     this.channels.set(channelId, { workerIndex, channel });
     this.workerChannelCounts[workerIndex]++;
+
+    // If the worker is already paused when the channel joins, propagate
+    // the signal so the channel queues writes from the start.
+    if (this.workerPaused[workerIndex]) {
+      channel.setPoolPaused(true);
+    }
 
     return channel;
   }
@@ -381,6 +401,8 @@ export class ParserPool {
     }
     this.workers.length = 0;
     this.workerChannelCounts.length = 0;
+    this.workerPendingBytes.length = 0;
+    this.workerPaused.length = 0;
   }
 
   // ---- Internals ------------------------------------------------------------
@@ -400,6 +422,46 @@ export class ParserPool {
       throw new Error("ParserPool: no live workers available");
     }
     return minIdx;
+  }
+
+  /** Send a write on behalf of a channel and update per-worker flow control. */
+  private sendWriteFromChannel(
+    workerIndex: number,
+    channelId: string,
+    buf: ArrayBuffer,
+    byteLength: number,
+  ): void {
+    if (this.disposed) return;
+    const worker = this.workers[workerIndex];
+    if (!worker) return;
+    worker.postMessage({ type: "write", channelId, data: buf }, [buf]);
+
+    this.workerPendingBytes[workerIndex] += byteLength;
+    if (!this.workerPaused[workerIndex] && this.workerPendingBytes[workerIndex] >= HIGH_WATERMARK) {
+      this.workerPaused[workerIndex] = true;
+      // Pause every channel on this worker.
+      for (const [, entry] of this.channels) {
+        if (entry.workerIndex === workerIndex) entry.channel.setPoolPaused(true);
+      }
+    }
+  }
+
+  /** Called by a channel after a flush; may unpause the worker. */
+  private onFlushProcessed(workerIndex: number, bytesProcessed: number): void {
+    if (this.disposed) return;
+    this.workerPendingBytes[workerIndex] = Math.max(
+      0,
+      this.workerPendingBytes[workerIndex] - bytesProcessed,
+    );
+    if (this.workerPaused[workerIndex] && this.workerPendingBytes[workerIndex] < LOW_WATERMARK) {
+      this.workerPaused[workerIndex] = false;
+      for (const [, entry] of this.channels) {
+        if (entry.workerIndex === workerIndex) {
+          entry.channel.setPoolPaused(false);
+          entry.channel.drainQueue();
+        }
+      }
+    }
   }
 
   /** Demux incoming messages by channelId to the correct ParserChannel. */

--- a/packages/web/src/parser-pool.ts
+++ b/packages/web/src/parser-pool.ts
@@ -108,12 +108,14 @@ export class ParserChannel {
       // Instead, surface the overflow so the consumer (WebTerminal) can
       // fall back to main-thread parsing.
       if (this.queuedBytes + data.byteLength > MAX_QUEUE_BYTES) {
-        this.disposed = true;
-        this.writeQueue.length = 0;
-        this.queuedBytes = 0;
-        this.onError?.(
-          `ParserChannel "${this.channelId}" queue exceeded ${MAX_QUEUE_BYTES} bytes — worker stalled, falling back`,
-        );
+        const errMessage = `ParserChannel "${this.channelId}" queue exceeded ${MAX_QUEUE_BYTES} bytes — worker stalled, falling back`;
+        // Tear down via the full dispose path FIRST so the worker is told
+        // the channel is gone and the pool removes the entry from its map.
+        // Otherwise the consumer's onError → releaseChannel → dispose()
+        // early-returns on `disposed`, leaving the pool + worker state
+        // leaked and preventing re-acquiring this paneId.
+        this.dispose();
+        this.onError?.(errMessage);
         return;
       }
       this.writeQueue.push(data);

--- a/packages/web/src/parser-pool.ts
+++ b/packages/web/src/parser-pool.ts
@@ -6,15 +6,26 @@
  * means 4 postMessage streams instead of 32, dramatically reducing overhead
  * while still keeping all parsing off the main thread.
  *
- * API mirrors SharedWebGLContext: created once at the container level,
- * channels are acquired/released per pane.
- *
  * Flow control is per-WORKER (not per-channel) so that the HIGH_WATERMARK
- * budget scales with worker capacity, not channel count. All channels on
- * a saturated worker pause together until that worker drains below
- * LOW_WATERMARK. This prevents the 8× queue inflation that per-channel
- * watermarks would otherwise cause (8 channels × 2 MB = 16 MB of in-flight
- * data sitting in one worker's postMessage queue).
+ * budget scales with worker capacity, not channel count. All channels on a
+ * saturated worker pause together until that worker drains below
+ * LOW_WATERMARK.
+ *
+ * IMPORTANT invariants:
+ *   - Pending-bytes bookkeeping is always reconciled in the pool's message
+ *     handler, not in ParserChannel. Flushes for disposed / mismatched /
+ *     unknown channels still decrement worker-level pendingBytes so the
+ *     worker never gets stuck in a permanent pause.
+ *   - Released channels deposit their still-pending bytes into a per-worker
+ *     "orphan" counter. The pool drains orphan bytes as flushes arrive so
+ *     the pause threshold is reconciled without waiting for the channel
+ *     (which no longer exists).
+ *   - Worker crashes terminate the worker, reset its flow-control counters,
+ *     and unpause all channels that were on it so they don't accumulate
+ *     queued writes while the consumer is deciding how to recover.
+ *   - Channel assignments carry a generation number that's included in
+ *     every message. Stale flushes from a prior lifecycle (after channelId
+ *     reuse) are dropped without polluting flow control.
  */
 
 import type { CursorState } from "@next_term/core";
@@ -26,9 +37,8 @@ import { HIGH_WATERMARK, LOW_WATERMARK, SAB_AVAILABLE } from "./worker-bridge.js
 
 /**
  * A channel within a shared parser worker. Same public API as WorkerBridge
- * but routes messages through a shared Worker via channelId.
- *
- * Flow control is delegated to the owning ParserPool — see class-level comment.
+ * but routes messages through a shared Worker via channelId. Flow control
+ * is owned by the pool — ParserChannel only tracks its own paused state.
  */
 export class ParserChannel {
   private grid: CellGrid;
@@ -37,9 +47,9 @@ export class ParserChannel {
   private onFlush: (isAlternate: boolean, modes: FlushMessage["modes"]) => void;
   private onError: ((message: string) => void) | null;
 
-  // Local state. Pause signal comes from the pool (per-worker saturation).
   private poolPaused = false;
   private writeQueue: Uint8Array[] = [];
+  private queuedBytes = 0;
   private skipFlushCellDataCount = 0;
 
   private disposed = false;
@@ -54,8 +64,8 @@ export class ParserChannel {
     ) => void,
     /** @internal — pool callback used by ParserChannel to post non-write messages */
     private readonly poolPost: (msg: unknown, transfer?: Transferable[]) => void,
-    /** @internal — pool callback used by ParserChannel on flush */
-    private readonly poolOnFlushProcessed: (bytesProcessed: number) => void,
+    /** @internal — pool callback invoked when channel is disposed with still-pending bytes */
+    private readonly poolOnChannelDispose: (channelId: string) => void,
     grid: CellGrid,
     altGrid: CellGrid,
     cursor: CursorState,
@@ -88,6 +98,7 @@ export class ParserChannel {
 
     if (this.poolPaused) {
       this.writeQueue.push(data);
+      this.queuedBytes += data.byteLength;
       return;
     }
 
@@ -104,6 +115,7 @@ export class ParserChannel {
     if (this.disposed) return;
 
     this.writeQueue.length = 0;
+    this.queuedBytes = 0;
 
     const msg: Record<string, unknown> = {
       type: "resize",
@@ -133,7 +145,11 @@ export class ParserChannel {
     if (this.disposed) return;
     this.disposed = true;
     this.poolPost({ type: "dispose", channelId: this.channelId });
+    // Pool needs to know the channel is gone so it can track any
+    // in-flight bytes as "orphan" (decremented when flushes arrive).
+    this.poolOnChannelDispose(this.channelId);
     this.writeQueue.length = 0;
+    this.queuedBytes = 0;
   }
 
   get isPaused(): boolean {
@@ -148,18 +164,19 @@ export class ParserChannel {
 
   // ---- Called by ParserPool's demux / flow control -------------------------
 
-  /** @internal — called by the pool when the worker becomes saturated or drains. */
+  /** @internal */
   setPoolPaused(paused: boolean): void {
     if (this.disposed) return;
     this.poolPaused = paused;
   }
 
-  /** @internal — drain queued writes when pool unpauses this channel's worker. */
+  /** @internal */
   drainQueue(): void {
     if (this.disposed) return;
     while (this.writeQueue.length > 0 && !this.poolPaused) {
       const next = this.writeQueue.shift();
       if (!next) break;
+      this.queuedBytes -= next.byteLength;
       this.sendWrite(next);
     }
   }
@@ -177,47 +194,46 @@ export class ParserChannel {
 
     if (this.skipFlushCellDataCount > 0 && msg.cellData) {
       this.skipFlushCellDataCount--;
-    } else if (msg.cellData && msg.dirtyRows) {
-      const targetGrid = msg.isAlternate ? this.altGrid : this.grid;
-      const cellView = new Uint32Array(msg.cellData);
-      const dirtyView = new Int32Array(msg.dirtyRows);
-      const cols = targetGrid.cols;
-      const rows = targetGrid.rows;
+      return;
+    }
+    if (!msg.cellData || !msg.dirtyRows) return;
 
-      const expectedCells = cols * rows * CELL_SIZE;
-      if (cellView.length !== expectedCells || dirtyView.length !== rows) {
-        // Stale flush for a different grid size — still tell the pool the
-        // bytes were processed so its worker counter stays accurate.
-        this.poolOnFlushProcessed(msg.bytesProcessed);
-        return;
-      }
+    const targetGrid = msg.isAlternate ? this.altGrid : this.grid;
+    const cellView = new Uint32Array(msg.cellData);
+    const dirtyView = new Int32Array(msg.dirtyRows);
+    const cols = targetGrid.cols;
+    const rows = targetGrid.rows;
 
-      const rowOffset = modPositive(msg.rowOffset ?? 0, rows);
-      targetGrid.rowOffsetData[0] = rowOffset;
+    const expectedCells = cols * rows * CELL_SIZE;
+    if (cellView.length !== expectedCells || dirtyView.length !== rows) {
+      // Stale flush for a different grid size — flow control is already
+      // reconciled by the pool before this is called.
+      return;
+    }
 
-      const rowLen = cols * CELL_SIZE;
-      for (let r = 0; r < rows; r++) {
-        if (dirtyView[r] !== 0) {
-          const physRow = modPositive(r + rowOffset, rows);
-          const start = physRow * rowLen;
-          const end = start + rowLen;
-          targetGrid.data.set(cellView.subarray(start, end), start);
-          targetGrid.markDirty(r);
-        }
-      }
+    const rowOffset = modPositive(msg.rowOffset ?? 0, rows);
+    targetGrid.rowOffsetData[0] = rowOffset;
 
-      if (msg.wrapFlags) {
-        const wrapView = new Int32Array(msg.wrapFlags);
-        if (wrapView.length === rows) {
-          targetGrid.wrapFlags.set(wrapView);
-        }
+    const rowLen = cols * CELL_SIZE;
+    for (let r = 0; r < rows; r++) {
+      if (dirtyView[r] !== 0) {
+        const physRow = modPositive(r + rowOffset, rows);
+        const start = physRow * rowLen;
+        const end = start + rowLen;
+        targetGrid.data.set(cellView.subarray(start, end), start);
+        targetGrid.markDirty(r);
       }
     }
 
-    this.poolOnFlushProcessed(msg.bytesProcessed);
+    if (msg.wrapFlags) {
+      const wrapView = new Int32Array(msg.wrapFlags);
+      if (wrapView.length === rows) {
+        targetGrid.wrapFlags.set(wrapView);
+      }
+    }
   }
 
-  /** @internal — called by the pool when an error arrives for this channel. */
+  /** @internal */
   handleError(message: string): void {
     if (this.disposed) return;
     this.onError?.(message);
@@ -261,27 +277,24 @@ export const DEFAULT_PARSER_WORKER_COUNT = Math.min(
   4,
 );
 
-/**
- * A pool of N parser Web Workers shared across many terminal panes.
- *
- * Usage:
- * ```ts
- * const pool = new ParserPool(4);
- * const channel = pool.acquireChannel("pane-0", grid, altGrid, cursor, onFlush);
- * channel.start(cols, rows, scrollback);
- * channel.write(data);
- * // ...
- * pool.releaseChannel("pane-0");
- * pool.dispose();
- * ```
- */
+interface ChannelEntry {
+  workerIndex: number;
+  /** Monotonic generation for this channelId. Incremented on each acquire so
+   *  stale flushes from a prior lifecycle can be dropped in the demux. */
+  generation: number;
+  channel: ParserChannel;
+}
+
 export class ParserPool {
   private workers: Worker[] = [];
-  private channels = new Map<string, { workerIndex: number; channel: ParserChannel }>();
+  private channels = new Map<string, ChannelEntry>();
   private workerChannelCounts: number[];
-  /** Per-worker flow control — pendingBytes is shared across all channels. */
+  /** Total bytes currently in-flight per worker (sum across all channels). */
   private workerPendingBytes: number[];
+  /** Per-worker paused state — saturated or not. */
   private workerPaused: boolean[];
+  /** Monotonic generation counter per channelId (defends against reuse races). */
+  private channelGenerations = new Map<string, number>();
   /** Workers that have crashed and should not receive new channel assignments. */
   private deadWorkers = new Set<number>();
   private disposed = false;
@@ -306,8 +319,6 @@ export class ParserPool {
         this.workers.push(worker);
       }
     } catch (err) {
-      // If mid-loop construction fails, terminate any workers already created
-      // so we don't leak them before throwing.
       for (const w of this.workers) {
         try {
           w.terminate();
@@ -318,15 +329,10 @@ export class ParserPool {
     }
   }
 
-  /** Number of workers in the pool. */
   get workerCount(): number {
     return this.workers.length;
   }
 
-  /**
-   * Acquire a channel for a terminal pane. The channel is assigned to the
-   * worker with the fewest current channels (least-loaded at assignment time).
-   */
   acquireChannel(
     channelId: string,
     grid: CellGrid,
@@ -338,21 +344,29 @@ export class ParserPool {
     if (this.disposed) {
       throw new Error("ParserPool is disposed");
     }
+    if (this.channels.has(channelId)) {
+      throw new Error(`ParserPool: channelId "${channelId}" is already in use`);
+    }
 
     const workerIndex = this.pickWorker();
     const worker = this.workers[workerIndex];
+    const generation = (this.channelGenerations.get(channelId) ?? 0) + 1;
+    this.channelGenerations.set(channelId, generation);
 
     const channel = new ParserChannel(
       channelId,
-      (cid, buf, byteLength) => this.sendWriteFromChannel(workerIndex, cid, buf, byteLength),
+      (cid, buf, byteLength) =>
+        this.sendWriteFromChannel(workerIndex, generation, cid, buf, byteLength),
       (msg, transfer) => {
-        if (transfer) {
-          worker.postMessage(msg, transfer);
-        } else {
-          worker.postMessage(msg);
-        }
+        // Tag with generation so stale flushes can be rejected in demux.
+        const tagged =
+          typeof msg === "object" && msg !== null
+            ? { ...(msg as Record<string, unknown>), generation }
+            : msg;
+        if (transfer) worker.postMessage(tagged, transfer);
+        else worker.postMessage(tagged);
       },
-      (bytesProcessed) => this.onFlushProcessed(workerIndex, bytesProcessed),
+      (cid) => this.onChannelDisposed(cid),
       grid,
       altGrid,
       cursor,
@@ -360,11 +374,9 @@ export class ParserPool {
       onError,
     );
 
-    this.channels.set(channelId, { workerIndex, channel });
+    this.channels.set(channelId, { workerIndex, generation, channel });
     this.workerChannelCounts[workerIndex]++;
 
-    // If the worker is already paused when the channel joins, propagate
-    // the signal so the channel queues writes from the start.
     if (this.workerPaused[workerIndex]) {
       channel.setPoolPaused(true);
     }
@@ -372,21 +384,14 @@ export class ParserPool {
     return channel;
   }
 
-  /**
-   * Release a channel. Sends dispose to the worker and cleans up.
-   */
   releaseChannel(channelId: string): void {
     const entry = this.channels.get(channelId);
     if (!entry) return;
 
+    // channel.dispose() calls onChannelDisposed which clears the entry.
     entry.channel.dispose();
-    this.workerChannelCounts[entry.workerIndex]--;
-    this.channels.delete(channelId);
   }
 
-  /**
-   * Dispose the entire pool — releases all channels and terminates all workers.
-   */
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
@@ -395,19 +400,22 @@ export class ParserPool {
       entry.channel.dispose();
     }
     this.channels.clear();
+    this.channelGenerations.clear();
 
     for (const worker of this.workers) {
-      worker.terminate();
+      try {
+        worker.terminate();
+      } catch {}
     }
     this.workers.length = 0;
     this.workerChannelCounts.length = 0;
     this.workerPendingBytes.length = 0;
     this.workerPaused.length = 0;
+    this.deadWorkers.clear();
   }
 
   // ---- Internals ------------------------------------------------------------
 
-  /** Pick the live worker with the fewest current channels. */
   private pickWorker(): number {
     let minIdx = -1;
     let minCount = Infinity;
@@ -424,31 +432,43 @@ export class ParserPool {
     return minIdx;
   }
 
-  /** Send a write on behalf of a channel and update per-worker flow control. */
   private sendWriteFromChannel(
     workerIndex: number,
+    generation: number,
     channelId: string,
     buf: ArrayBuffer,
     byteLength: number,
   ): void {
-    if (this.disposed) return;
+    if (this.disposed || this.deadWorkers.has(workerIndex)) return;
     const worker = this.workers[workerIndex];
     if (!worker) return;
-    worker.postMessage({ type: "write", channelId, data: buf }, [buf]);
+    worker.postMessage({ type: "write", channelId, generation, data: buf }, [buf]);
 
     this.workerPendingBytes[workerIndex] += byteLength;
     if (!this.workerPaused[workerIndex] && this.workerPendingBytes[workerIndex] >= HIGH_WATERMARK) {
       this.workerPaused[workerIndex] = true;
-      // Pause every channel on this worker.
       for (const [, entry] of this.channels) {
         if (entry.workerIndex === workerIndex) entry.channel.setPoolPaused(true);
       }
     }
   }
 
-  /** Called by a channel after a flush; may unpause the worker. */
-  private onFlushProcessed(workerIndex: number, bytesProcessed: number): void {
-    if (this.disposed) return;
+  /** Called when a channel disposes itself — tracks any still-pending bytes
+   *  so worker-level flow control stays correct as flushes arrive later. */
+  private onChannelDisposed(channelId: string): void {
+    const entry = this.channels.get(channelId);
+    if (!entry) return;
+    this.workerChannelCounts[entry.workerIndex]--;
+    this.channels.delete(channelId);
+    // Note: bytes in flight to the worker for this channel will still come
+    // back as flushes. decrementWorkerPending handles that path for
+    // channel-less flushes.
+  }
+
+  /** Decrement worker-level pendingBytes, unpausing if we cross LOW_WATERMARK.
+   *  Called for EVERY flush, including stale / unknown / disposed channels,
+   *  so the pause state never gets stuck. */
+  private decrementWorkerPending(workerIndex: number, bytesProcessed: number): void {
     this.workerPendingBytes[workerIndex] = Math.max(
       0,
       this.workerPendingBytes[workerIndex] - bytesProcessed,
@@ -464,18 +484,27 @@ export class ParserPool {
     }
   }
 
-  /** Demux incoming messages by channelId to the correct ParserChannel. */
   private handleWorkerMessage(workerIndex: number, event: MessageEvent<OutboundMessage>): void {
     if (this.disposed) return;
     const msg = event.data;
+
+    // Always reconcile flow control for flushes first, regardless of whether
+    // the channel is still live. This is the invariant that prevents the
+    // worker from getting stuck in a permanent pause when channels are
+    // released with bytes in flight.
+    if (msg.type === "flush" && typeof msg.bytesProcessed === "number") {
+      this.decrementWorkerPending(workerIndex, msg.bytesProcessed);
+    }
+
     const channelId = msg.channelId;
-    if (!channelId) return; // no channelId = legacy message, shouldn't happen in pool
-
+    if (!channelId) return;
     const entry = this.channels.get(channelId);
-    if (!entry) return; // channel already disposed
+    if (!entry) return;
 
-    // Guard against channelId reuse: if the channel was released and
-    // re-acquired on a different worker, drop stale flushes from the old one.
+    // Drop stale messages from a prior lifecycle of this channelId.
+    const gen = (msg as unknown as { generation?: number }).generation;
+    if (typeof gen === "number" && gen !== entry.generation) return;
+    // Also drop if somehow the entry was reassigned to a different worker.
     if (entry.workerIndex !== workerIndex) return;
 
     if (msg.type === "error") {
@@ -485,14 +514,24 @@ export class ParserPool {
     }
   }
 
-  /** Forward worker errors to all channels on that worker and mark it dead. */
   private handleWorkerError(workerIndex: number, event: ErrorEvent): void {
-    // Mark the worker as dead BEFORE forwarding errors — the error callbacks
-    // may synchronously call releaseChannel, which would otherwise see the
-    // worker as live and leave workerChannelCounts in an inconsistent state.
+    // Mark dead BEFORE forwarding errors so synchronous release callbacks
+    // that read pool state see the correct worker as unavailable.
     this.deadWorkers.add(workerIndex);
+
+    // Reset flow-control state for this worker — nothing more is coming
+    // back from it, and channels that remain should not keep queueing.
+    this.workerPendingBytes[workerIndex] = 0;
+    this.workerPaused[workerIndex] = false;
+
+    // Terminate the dead worker so it doesn't keep holding resources.
+    try {
+      this.workers[workerIndex]?.terminate();
+    } catch {}
+
     for (const [, entry] of this.channels) {
       if (entry.workerIndex === workerIndex) {
+        entry.channel.setPoolPaused(false);
         entry.channel.handleError(`Worker error: ${event.message}`);
       }
     }

--- a/packages/web/src/parser-worker.ts
+++ b/packages/web/src/parser-worker.ts
@@ -5,6 +5,11 @@
  * the worker writes directly into the SAB that the main-thread renderer reads.
  * Otherwise it owns the buffer and transfers cell data back via Transferable
  * ArrayBuffers in the flush message.
+ *
+ * Supports multi-channel mode: when messages include a `channelId`, the worker
+ * maintains independent parser/grid state per channel. This allows a pool of N
+ * workers to serve many more terminal panes without thread oversubscription.
+ * Messages without `channelId` use the legacy singleton path for backward compat.
  */
 
 import { BufferSet, VTParser } from "@next_term/core";
@@ -21,6 +26,7 @@ declare type DedicatedWorkerGlobalScope = typeof globalThis & {
 /** Messages the worker can receive from the main thread. */
 interface InitMessage {
   type: "init";
+  channelId?: string;
   cols: number;
   rows: number;
   scrollback: number;
@@ -32,11 +38,13 @@ interface InitMessage {
 
 interface WriteMessage {
   type: "write";
+  channelId?: string;
   data: ArrayBuffer; // Transferable
 }
 
 interface ResizeMessage {
   type: "resize";
+  channelId?: string;
   cols: number;
   rows: number;
   scrollback: number;
@@ -52,6 +60,7 @@ interface ResizeMessage {
 
 interface DisposeMessage {
   type: "dispose";
+  channelId?: string;
 }
 
 type InboundMessage = InitMessage | WriteMessage | ResizeMessage | DisposeMessage;
@@ -59,6 +68,7 @@ type InboundMessage = InitMessage | WriteMessage | ResizeMessage | DisposeMessag
 /** Messages the worker posts back to the main thread. */
 export interface FlushMessage {
   type: "flush";
+  channelId?: string;
   cursor: { row: number; col: number; visible: boolean; style: string };
   /** true when the parser switched to or from the alternate buffer. */
   isAlternate: boolean;
@@ -87,6 +97,7 @@ export interface FlushMessage {
 
 export interface ErrorMessage {
   type: "error";
+  channelId?: string;
   message: string;
 }
 
@@ -94,6 +105,17 @@ export type OutboundMessage = FlushMessage | ErrorMessage;
 
 // ---- Worker state ----------------------------------------------------------
 
+/** Per-channel state for multi-channel mode. */
+interface ChannelState {
+  bufferSet: BufferSet;
+  parser: VTParser;
+  usingSAB: boolean;
+}
+
+/** Multi-channel state. */
+const channels = new Map<string, ChannelState>();
+
+/** Legacy singleton state (messages without channelId). */
 let bufferSet: BufferSet | null = null;
 let parser: VTParser | null = null;
 let usingSAB = false;
@@ -106,42 +128,40 @@ function createBufferAndParser(
   scrollback: number,
   sharedBuffer?: SharedArrayBuffer,
   sharedAltBuffer?: SharedArrayBuffer,
-): void {
-  bufferSet = new BufferSet(cols, rows, scrollback, sharedBuffer, sharedAltBuffer);
-  parser = new VTParser(bufferSet);
+): ChannelState {
+  const bs = new BufferSet(cols, rows, scrollback, sharedBuffer, sharedAltBuffer);
+  const p = new VTParser(bs);
+  return { bufferSet: bs, parser: p, usingSAB: sharedBuffer !== undefined };
 }
 
-function buildFlush(bytesProcessed: number): FlushMessage {
-  if (!bufferSet || !parser) {
-    throw new Error("Worker not initialised");
-  }
-
-  const cursor = parser.cursor;
+function buildFlush(ch: ChannelState, bytesProcessed: number, channelId?: string): FlushMessage {
+  const cursor = ch.parser.cursor;
 
   const msg: FlushMessage = {
     type: "flush",
+    channelId,
     cursor: {
       row: cursor.row,
       col: cursor.col,
       visible: cursor.visible,
       style: cursor.style,
     },
-    isAlternate: bufferSet.isAlternate,
+    isAlternate: ch.bufferSet.isAlternate,
     bytesProcessed,
     modes: {
-      applicationCursorKeys: parser.applicationCursorKeys,
-      bracketedPasteMode: parser.bracketedPasteMode,
-      mouseProtocol: parser.mouseProtocol,
-      mouseEncoding: parser.mouseEncoding,
-      sendFocusEvents: parser.sendFocusEvents,
-      kittyFlags: parser.kittyFlags,
-      syncedOutput: parser.syncedOutput,
+      applicationCursorKeys: ch.parser.applicationCursorKeys,
+      bracketedPasteMode: ch.parser.bracketedPasteMode,
+      mouseProtocol: ch.parser.mouseProtocol,
+      mouseEncoding: ch.parser.mouseEncoding,
+      sendFocusEvents: ch.parser.sendFocusEvents,
+      kittyFlags: ch.parser.kittyFlags,
+      syncedOutput: ch.parser.syncedOutput,
     },
   };
 
-  if (!usingSAB) {
+  if (!ch.usingSAB) {
     // Transfer cell data, dirty flags, and wrap flags to the main thread.
-    const grid = bufferSet.active.grid;
+    const grid = ch.bufferSet.active.grid;
     const cellCopy = grid.data.slice().buffer;
     const dirtyCopy = grid.dirtyRows.slice().buffer;
     const wrapCopy = grid.wrapFlags.slice().buffer;
@@ -154,61 +174,75 @@ function buildFlush(bytesProcessed: number): FlushMessage {
   return msg;
 }
 
+function postFlush(flush: FlushMessage, usingSABMode: boolean): void {
+  if (usingSABMode) {
+    (self as unknown as DedicatedWorkerGlobalScope).postMessage(flush);
+  } else {
+    const transferables: ArrayBuffer[] = [];
+    if (flush.cellData) transferables.push(flush.cellData);
+    if (flush.dirtyRows) transferables.push(flush.dirtyRows);
+    if (flush.wrapFlags) transferables.push(flush.wrapFlags);
+    (self as unknown as DedicatedWorkerGlobalScope).postMessage(flush, transferables);
+  }
+}
+
 // ---- Message handler -------------------------------------------------------
 
 function handleMessage(msg: InboundMessage): void {
+  const channelId = msg.channelId;
+
+  // Multi-channel path: route by channelId
+  if (channelId !== undefined) {
+    handleChannelMessage(msg, channelId);
+    return;
+  }
+
+  // Legacy singleton path (backward compat)
   switch (msg.type) {
     case "init": {
+      // Set usingSAB before creating buffers — if BufferSet throws (e.g.
+      // undersized SAB), the flag must still reflect the intent so writes
+      // against the previous bufferSet use the correct flush mode.
       usingSAB = msg.sharedBuffer !== undefined;
-      createBufferAndParser(
+      const ch = createBufferAndParser(
         msg.cols,
         msg.rows,
         msg.scrollback,
         msg.sharedBuffer,
         msg.sharedAltBuffer,
       );
+      bufferSet = ch.bufferSet;
+      parser = ch.parser;
       break;
     }
 
     case "write": {
-      if (!parser) {
+      if (!parser || !bufferSet) {
         postError("Worker not initialised — ignoring write");
         return;
       }
       const bytes = new Uint8Array(msg.data);
       parser.write(bytes);
-      const flush = buildFlush(bytes.length);
-
-      if (usingSAB) {
-        (self as unknown as DedicatedWorkerGlobalScope).postMessage(flush);
-      } else {
-        // Transfer the ArrayBuffers so they are zero-copy.
-        const transferables: ArrayBuffer[] = [];
-        if (flush.cellData) transferables.push(flush.cellData);
-        if (flush.dirtyRows) transferables.push(flush.dirtyRows);
-        if (flush.wrapFlags) transferables.push(flush.wrapFlags);
-        (self as unknown as DedicatedWorkerGlobalScope).postMessage(flush, transferables);
-      }
+      const flush = buildFlush({ bufferSet, parser, usingSAB }, bytes.length);
+      postFlush(flush, usingSAB);
       break;
     }
 
     case "resize": {
-      createBufferAndParser(
+      const ch = createBufferAndParser(
         msg.cols,
         msg.rows,
         msg.scrollback,
         msg.sharedBuffer,
         msg.sharedAltBuffer,
       );
-      // Restore cursor position after reflow so the parser continues
-      // at the right spot — prevents shell SIGWINCH response from
-      // overwriting reflowed content at (0,0).
+      bufferSet = ch.bufferSet;
+      parser = ch.parser;
+      usingSAB = ch.usingSAB;
       if (parser && bufferSet && msg.cursorRow != null && msg.cursorCol != null) {
         parser.cursor.row = Math.max(0, Math.min(msg.cursorRow, msg.rows - 1));
         parser.cursor.col = Math.max(0, Math.min(msg.cursorCol, msg.cols - 1));
       }
-      // In non-SAB mode, seed the worker's grid with the main thread's
-      // reflowed data so subsequent flushes don't send blank content.
       if (!usingSAB && bufferSet && msg.reflowedCellData && msg.reflowedWrapFlags) {
         const grid = bufferSet.active.grid;
         const cellView = new Uint32Array(msg.reflowedCellData);
@@ -221,32 +255,88 @@ function handleMessage(msg: InboundMessage): void {
         }
         grid.markAllDirty();
       }
-      // Send a full flush so the main thread gets initial state.
-      const flush = buildFlush(0);
-      if (!usingSAB) {
-        const transferables: ArrayBuffer[] = [];
-        if (flush.cellData) transferables.push(flush.cellData);
-        if (flush.dirtyRows) transferables.push(flush.dirtyRows);
-        if (flush.wrapFlags) transferables.push(flush.wrapFlags);
-        (self as unknown as DedicatedWorkerGlobalScope).postMessage(flush, transferables);
-      } else {
-        (self as unknown as DedicatedWorkerGlobalScope).postMessage(flush);
-      }
+      const flush = buildFlush({ bufferSet, parser, usingSAB }, 0);
+      postFlush(flush, usingSAB);
       break;
     }
 
     case "dispose": {
       bufferSet = null;
       parser = null;
-      // Close the worker — it cannot be reused.
+      // Close the worker — it cannot be reused (legacy single-channel mode).
       (self as unknown as DedicatedWorkerGlobalScope).close();
       break;
     }
   }
 }
 
-function postError(message: string): void {
-  const err: ErrorMessage = { type: "error", message };
+function handleChannelMessage(msg: InboundMessage, channelId: string): void {
+  switch (msg.type) {
+    case "init": {
+      const ch = createBufferAndParser(
+        msg.cols,
+        msg.rows,
+        msg.scrollback,
+        msg.sharedBuffer,
+        msg.sharedAltBuffer,
+      );
+      channels.set(channelId, ch);
+      break;
+    }
+
+    case "write": {
+      const ch = channels.get(channelId);
+      if (!ch) {
+        postError(`Channel "${channelId}" not initialised — ignoring write`, channelId);
+        return;
+      }
+      const bytes = new Uint8Array(msg.data);
+      ch.parser.write(bytes);
+      const flush = buildFlush(ch, bytes.length, channelId);
+      postFlush(flush, ch.usingSAB);
+      break;
+    }
+
+    case "resize": {
+      const newCh = createBufferAndParser(
+        msg.cols,
+        msg.rows,
+        msg.scrollback,
+        msg.sharedBuffer,
+        msg.sharedAltBuffer,
+      );
+      channels.set(channelId, newCh);
+      if (msg.cursorRow != null && msg.cursorCol != null) {
+        newCh.parser.cursor.row = Math.max(0, Math.min(msg.cursorRow, msg.rows - 1));
+        newCh.parser.cursor.col = Math.max(0, Math.min(msg.cursorCol, msg.cols - 1));
+      }
+      if (!newCh.usingSAB && msg.reflowedCellData && msg.reflowedWrapFlags) {
+        const grid = newCh.bufferSet.active.grid;
+        const cellView = new Uint32Array(msg.reflowedCellData);
+        if (cellView.length === grid.data.length) {
+          grid.data.set(cellView);
+        }
+        const wrapView = new Int32Array(msg.reflowedWrapFlags);
+        if (wrapView.length === grid.wrapFlags.length) {
+          grid.wrapFlags.set(wrapView);
+        }
+        grid.markAllDirty();
+      }
+      const flush = buildFlush(newCh, 0, channelId);
+      postFlush(flush, newCh.usingSAB);
+      break;
+    }
+
+    case "dispose": {
+      channels.delete(channelId);
+      // Do NOT close the worker — other channels may still be active.
+      break;
+    }
+  }
+}
+
+function postError(message: string, channelId?: string): void {
+  const err: ErrorMessage = { type: "error", channelId, message };
   (self as unknown as DedicatedWorkerGlobalScope).postMessage(err);
 }
 
@@ -258,7 +348,7 @@ function postError(message: string): void {
     try {
       handleMessage(event.data);
     } catch (e: unknown) {
-      postError(e instanceof Error ? e.message : "Internal parser error");
+      postError(e instanceof Error ? e.message : "Internal parser error", event.data?.channelId);
     }
   },
 );

--- a/packages/web/src/parser-worker.ts
+++ b/packages/web/src/parser-worker.ts
@@ -27,6 +27,9 @@ declare type DedicatedWorkerGlobalScope = typeof globalThis & {
 interface InitMessage {
   type: "init";
   channelId?: string;
+  /** Monotonic per-channelId — echoed back on flushes so the pool can drop
+   *  stale messages from a previous lifecycle. */
+  generation?: number;
   cols: number;
   rows: number;
   scrollback: number;
@@ -39,12 +42,14 @@ interface InitMessage {
 interface WriteMessage {
   type: "write";
   channelId?: string;
+  generation?: number;
   data: ArrayBuffer; // Transferable
 }
 
 interface ResizeMessage {
   type: "resize";
   channelId?: string;
+  generation?: number;
   cols: number;
   rows: number;
   scrollback: number;
@@ -61,6 +66,7 @@ interface ResizeMessage {
 interface DisposeMessage {
   type: "dispose";
   channelId?: string;
+  generation?: number;
 }
 
 type InboundMessage = InitMessage | WriteMessage | ResizeMessage | DisposeMessage;
@@ -69,6 +75,9 @@ type InboundMessage = InitMessage | WriteMessage | ResizeMessage | DisposeMessag
 export interface FlushMessage {
   type: "flush";
   channelId?: string;
+  /** Echoed from the init that created the channel. Pool uses this to
+   *  drop stale flushes after channelId reuse on the same worker. */
+  generation?: number;
   cursor: { row: number; col: number; visible: boolean; style: string };
   /** true when the parser switched to or from the alternate buffer. */
   isAlternate: boolean;
@@ -98,6 +107,7 @@ export interface FlushMessage {
 export interface ErrorMessage {
   type: "error";
   channelId?: string;
+  generation?: number;
   message: string;
 }
 
@@ -110,6 +120,8 @@ interface ChannelState {
   bufferSet: BufferSet;
   parser: VTParser;
   usingSAB: boolean;
+  /** Stored from init; echoed on every outbound flush/error for this channel. */
+  generation: number | undefined;
 }
 
 /** Multi-channel state. */
@@ -128,6 +140,7 @@ function createBufferAndParser(
   scrollback: number,
   sharedBuffer?: SharedArrayBuffer,
   sharedAltBuffer?: SharedArrayBuffer,
+  generation?: number,
 ): ChannelState {
   const bs = new BufferSet(cols, rows, scrollback, sharedBuffer, sharedAltBuffer);
   const p = new VTParser(bs);
@@ -135,6 +148,7 @@ function createBufferAndParser(
     bufferSet: bs,
     parser: p,
     usingSAB: sharedBuffer !== undefined,
+    generation,
   };
 }
 
@@ -144,6 +158,7 @@ function buildFlush(ch: ChannelState, bytesProcessed: number, channelId?: string
   const msg: FlushMessage = {
     type: "flush",
     channelId,
+    generation: ch.generation,
     cursor: {
       row: cursor.row,
       col: cursor.col,
@@ -227,7 +242,10 @@ function handleMessage(msg: InboundMessage): void {
       }
       const bytes = new Uint8Array(msg.data);
       parser.write(bytes);
-      const flush = buildFlush({ bufferSet, parser, usingSAB }, bytes.length);
+      const flush = buildFlush(
+        { bufferSet, parser, usingSAB, generation: undefined },
+        bytes.length,
+      );
       postFlush(flush, usingSAB);
       break;
     }
@@ -259,7 +277,7 @@ function handleMessage(msg: InboundMessage): void {
         }
         grid.markAllDirty();
       }
-      const flush = buildFlush({ bufferSet, parser, usingSAB }, 0);
+      const flush = buildFlush({ bufferSet, parser, usingSAB, generation: undefined }, 0);
       postFlush(flush, usingSAB);
       break;
     }
@@ -283,6 +301,7 @@ function handleChannelMessage(msg: InboundMessage, channelId: string): void {
         msg.scrollback,
         msg.sharedBuffer,
         msg.sharedAltBuffer,
+        msg.generation,
       );
       channels.set(channelId, ch);
       break;
@@ -291,9 +310,16 @@ function handleChannelMessage(msg: InboundMessage, channelId: string): void {
     case "write": {
       const ch = channels.get(channelId);
       if (!ch) {
-        postError(`Channel "${channelId}" not initialised — ignoring write`, channelId);
+        postError(
+          `Channel "${channelId}" not initialised — ignoring write`,
+          channelId,
+          msg.generation,
+        );
         return;
       }
+      // Drop writes whose generation doesn't match the channel's current
+      // lifecycle — these are from a prior acquire that was disposed.
+      if (msg.generation !== undefined && msg.generation !== ch.generation) return;
       const bytes = new Uint8Array(msg.data);
       ch.parser.write(bytes);
       const flush = buildFlush(ch, bytes.length, channelId);
@@ -302,12 +328,18 @@ function handleChannelMessage(msg: InboundMessage, channelId: string): void {
     }
 
     case "resize": {
+      const existing = channels.get(channelId);
+      // Drop stale resize from a prior lifecycle.
+      if (existing && msg.generation !== undefined && msg.generation !== existing.generation) {
+        return;
+      }
       const newCh = createBufferAndParser(
         msg.cols,
         msg.rows,
         msg.scrollback,
         msg.sharedBuffer,
         msg.sharedAltBuffer,
+        msg.generation ?? existing?.generation,
       );
       channels.set(channelId, newCh);
       if (msg.cursorRow != null && msg.cursorCol != null) {
@@ -332,6 +364,13 @@ function handleChannelMessage(msg: InboundMessage, channelId: string): void {
     }
 
     case "dispose": {
+      const existing = channels.get(channelId);
+      // Drop stale dispose from a prior lifecycle — the newer init has
+      // already taken over this channelId. (This can happen if the main
+      // thread re-acquires while the prior dispose is still in flight.)
+      if (existing && msg.generation !== undefined && msg.generation !== existing.generation) {
+        return;
+      }
       channels.delete(channelId);
       // Do NOT close the worker — other channels may still be active.
       break;
@@ -339,8 +378,8 @@ function handleChannelMessage(msg: InboundMessage, channelId: string): void {
   }
 }
 
-function postError(message: string, channelId?: string): void {
-  const err: ErrorMessage = { type: "error", channelId, message };
+function postError(message: string, channelId?: string, generation?: number): void {
+  const err: ErrorMessage = { type: "error", channelId, generation, message };
   (self as unknown as DedicatedWorkerGlobalScope).postMessage(err);
 }
 
@@ -352,7 +391,11 @@ function postError(message: string, channelId?: string): void {
     try {
       handleMessage(event.data);
     } catch (e: unknown) {
-      postError(e instanceof Error ? e.message : "Internal parser error", event.data?.channelId);
+      postError(
+        e instanceof Error ? e.message : "Internal parser error",
+        event.data?.channelId,
+        event.data?.generation,
+      );
     }
   },
 );

--- a/packages/web/src/parser-worker.ts
+++ b/packages/web/src/parser-worker.ts
@@ -110,10 +110,15 @@ interface ChannelState {
   bufferSet: BufferSet;
   parser: VTParser;
   usingSAB: boolean;
+  /** Pending write buffers queued for round-robin draining. */
+  writeQueue: ArrayBuffer[];
 }
 
 /** Multi-channel state. */
 const channels = new Map<string, ChannelState>();
+
+/** Set to true when a round-robin drain is already scheduled. */
+let drainScheduled = false;
 
 /** Legacy singleton state (messages without channelId). */
 let bufferSet: BufferSet | null = null;
@@ -131,7 +136,12 @@ function createBufferAndParser(
 ): ChannelState {
   const bs = new BufferSet(cols, rows, scrollback, sharedBuffer, sharedAltBuffer);
   const p = new VTParser(bs);
-  return { bufferSet: bs, parser: p, usingSAB: sharedBuffer !== undefined };
+  return {
+    bufferSet: bs,
+    parser: p,
+    usingSAB: sharedBuffer !== undefined,
+    writeQueue: [],
+  };
 }
 
 function buildFlush(ch: ChannelState, bytesProcessed: number, channelId?: string): FlushMessage {
@@ -290,10 +300,10 @@ function handleChannelMessage(msg: InboundMessage, channelId: string): void {
         postError(`Channel "${channelId}" not initialised — ignoring write`, channelId);
         return;
       }
-      const bytes = new Uint8Array(msg.data);
-      ch.parser.write(bytes);
-      const flush = buildFlush(ch, bytes.length, channelId);
-      postFlush(flush, ch.usingSAB);
+      // Enqueue for round-robin draining so one channel's burst doesn't
+      // head-of-line block other channels sharing this worker.
+      ch.writeQueue.push(msg.data);
+      scheduleDrain();
       break;
     }
 
@@ -328,6 +338,8 @@ function handleChannelMessage(msg: InboundMessage, channelId: string): void {
     }
 
     case "dispose": {
+      const existing = channels.get(channelId);
+      if (existing) existing.writeQueue.length = 0;
       channels.delete(channelId);
       // Do NOT close the worker — other channels may still be active.
       break;
@@ -338,6 +350,43 @@ function handleChannelMessage(msg: InboundMessage, channelId: string): void {
 function postError(message: string, channelId?: string): void {
   const err: ErrorMessage = { type: "error", channelId, message };
   (self as unknown as DedicatedWorkerGlobalScope).postMessage(err);
+}
+
+/**
+ * Schedule a round-robin drain of all channels' write queues. Fairness
+ * (no head-of-line blocking across channels) requires processing one
+ * chunk from each channel per cycle rather than FIFO across channels.
+ *
+ * The microtask defers draining until the current message event finishes,
+ * which lets multiple writes from different channels accumulate so the
+ * round-robin has something to fair-share.
+ */
+function scheduleDrain(): void {
+  if (drainScheduled) return;
+  drainScheduled = true;
+  queueMicrotask(drainChannelWrites);
+}
+
+function drainChannelWrites(): void {
+  drainScheduled = false;
+  // Round-robin: one chunk per channel per cycle, repeat until all empty.
+  let hadWork = true;
+  while (hadWork) {
+    hadWork = false;
+    for (const [channelId, ch] of channels) {
+      const buf = ch.writeQueue.shift();
+      if (!buf) continue;
+      hadWork = true;
+      try {
+        const bytes = new Uint8Array(buf);
+        ch.parser.write(bytes);
+        const flush = buildFlush(ch, bytes.length, channelId);
+        postFlush(flush, ch.usingSAB);
+      } catch (e: unknown) {
+        postError(e instanceof Error ? e.message : "Parser error", channelId);
+      }
+    }
+  }
 }
 
 // ---- Bootstrap -------------------------------------------------------------

--- a/packages/web/src/parser-worker.ts
+++ b/packages/web/src/parser-worker.ts
@@ -110,15 +110,10 @@ interface ChannelState {
   bufferSet: BufferSet;
   parser: VTParser;
   usingSAB: boolean;
-  /** Pending write buffers queued for round-robin draining. */
-  writeQueue: ArrayBuffer[];
 }
 
 /** Multi-channel state. */
 const channels = new Map<string, ChannelState>();
-
-/** Set to true when a round-robin drain is already scheduled. */
-let drainScheduled = false;
 
 /** Legacy singleton state (messages without channelId). */
 let bufferSet: BufferSet | null = null;
@@ -140,7 +135,6 @@ function createBufferAndParser(
     bufferSet: bs,
     parser: p,
     usingSAB: sharedBuffer !== undefined,
-    writeQueue: [],
   };
 }
 
@@ -300,10 +294,10 @@ function handleChannelMessage(msg: InboundMessage, channelId: string): void {
         postError(`Channel "${channelId}" not initialised — ignoring write`, channelId);
         return;
       }
-      // Enqueue for round-robin draining so one channel's burst doesn't
-      // head-of-line block other channels sharing this worker.
-      ch.writeQueue.push(msg.data);
-      scheduleDrain();
+      const bytes = new Uint8Array(msg.data);
+      ch.parser.write(bytes);
+      const flush = buildFlush(ch, bytes.length, channelId);
+      postFlush(flush, ch.usingSAB);
       break;
     }
 
@@ -338,8 +332,6 @@ function handleChannelMessage(msg: InboundMessage, channelId: string): void {
     }
 
     case "dispose": {
-      const existing = channels.get(channelId);
-      if (existing) existing.writeQueue.length = 0;
       channels.delete(channelId);
       // Do NOT close the worker — other channels may still be active.
       break;
@@ -350,43 +342,6 @@ function handleChannelMessage(msg: InboundMessage, channelId: string): void {
 function postError(message: string, channelId?: string): void {
   const err: ErrorMessage = { type: "error", channelId, message };
   (self as unknown as DedicatedWorkerGlobalScope).postMessage(err);
-}
-
-/**
- * Schedule a round-robin drain of all channels' write queues. Fairness
- * (no head-of-line blocking across channels) requires processing one
- * chunk from each channel per cycle rather than FIFO across channels.
- *
- * The microtask defers draining until the current message event finishes,
- * which lets multiple writes from different channels accumulate so the
- * round-robin has something to fair-share.
- */
-function scheduleDrain(): void {
-  if (drainScheduled) return;
-  drainScheduled = true;
-  queueMicrotask(drainChannelWrites);
-}
-
-function drainChannelWrites(): void {
-  drainScheduled = false;
-  // Round-robin: one chunk per channel per cycle, repeat until all empty.
-  let hadWork = true;
-  while (hadWork) {
-    hadWork = false;
-    for (const [channelId, ch] of channels) {
-      const buf = ch.writeQueue.shift();
-      if (!buf) continue;
-      hadWork = true;
-      try {
-        const bytes = new Uint8Array(buf);
-        ch.parser.write(bytes);
-        const flush = buildFlush(ch, bytes.length, channelId);
-        postFlush(flush, ch.usingSAB);
-      } catch (e: unknown) {
-        postError(e instanceof Error ? e.message : "Parser error", channelId);
-      }
-    }
-  }
 }
 
 // ---- Bootstrap -------------------------------------------------------------

--- a/packages/web/src/web-terminal.ts
+++ b/packages/web/src/web-terminal.ts
@@ -248,11 +248,17 @@ export class WebTerminal {
       fontWeightBold,
     };
 
+    // paneId is used by both SharedWebGLContext AND ParserPool as the channel
+    // identifier. Set it whenever it's provided, not just when shared rendering
+    // is also in play — otherwise the parser pool is silently bypassed.
+    if (options?.paneId) {
+      this.paneId = options.paneId;
+    }
+
     if (options?.sharedContext && options?.paneId) {
       // Shared WebGL context mode: register with the shared context
       // instead of creating our own renderer.
       this.sharedContext = options.sharedContext;
-      this.paneId = options.paneId;
 
       const grid = this.bufferSet.active.grid;
       const cursor = this.bufferSet.active.cursor;

--- a/packages/web/src/web-terminal.ts
+++ b/packages/web/src/web-terminal.ts
@@ -456,6 +456,11 @@ export class WebTerminal {
         );
       }
 
+      // Schedule a11y update after cell data application. The onFlush
+      // callback runs before the grid is updated, so defer via microtask
+      // so the accessibility tree reads the fresh grid state.
+      queueMicrotask(() => this.accessibilityManager?.update());
+
       if (this.viewportOffset > 0 && !altChanged) return;
 
       const { grid, cursor } = this.bufferSet.active;

--- a/packages/web/src/web-terminal.ts
+++ b/packages/web/src/web-terminal.ts
@@ -262,7 +262,7 @@ export class WebTerminal {
 
       const grid = this.bufferSet.active.grid;
       const cursor = this.bufferSet.active.cursor;
-      this.sharedContext.addTerminal(this.paneId, grid, cursor);
+      this.sharedContext.addTerminal(options.paneId, grid, cursor);
 
       // The canvas is not appended to the DOM — shared context owns the canvas.
       // But we still need a container div for input handling.

--- a/packages/web/src/web-terminal.ts
+++ b/packages/web/src/web-terminal.ts
@@ -82,8 +82,10 @@ export interface WebTerminalOptions {
    */
   sharedContext?: SharedWebGLContext;
   /**
-   * Unique identifier for this pane within a SharedWebGLContext.
-   * Required when `sharedContext` is provided.
+   * Unique identifier for this pane. Required when `sharedContext` OR
+   * `parserPool` is provided — used as the channel id in both. Passing
+   * either without `paneId` logs a warning and silently skips that
+   * shared resource for this terminal.
    */
   paneId?: string;
   /**
@@ -253,6 +255,14 @@ export class WebTerminal {
     // is also in play — otherwise the parser pool is silently bypassed.
     if (options?.paneId) {
       this.paneId = options.paneId;
+    } else if (options?.sharedContext || options?.parserPool) {
+      // Misconfiguration: a shared resource was provided but no paneId.
+      // We can't register the terminal with the shared context/pool, so
+      // both are silently skipped. Warn once at construction so consumers
+      // notice rather than debugging "why is my pool unused?".
+      console.warn(
+        "[WebTerminal] sharedContext/parserPool provided without paneId — shared resources will NOT be used for this terminal. Pass a unique paneId to opt in.",
+      );
     }
 
     if (options?.sharedContext && options?.paneId) {

--- a/packages/web/src/web-terminal.ts
+++ b/packages/web/src/web-terminal.ts
@@ -1300,15 +1300,17 @@ export class WebTerminal {
     for (const addon of this.addons) addon.dispose();
     this.addons = [];
 
+    // Release parser channel BEFORE clearing paneId — the pool keys
+    // channels by paneId so it must still be set here.
+    if (this.parserChannel && this.parserPool && this.paneId) {
+      this.parserPool.releaseChannel(this.paneId);
+      this.parserChannel = null;
+    }
+
     if (this.sharedContext && this.paneId) {
       this.sharedContext.removeTerminal(this.paneId);
       this.sharedContext = null;
       this.paneId = null;
-    }
-
-    if (this.parserChannel && this.parserPool && this.paneId) {
-      this.parserPool.releaseChannel(this.paneId);
-      this.parserChannel = null;
     }
     if (this.workerBridge) {
       this.workerBridge.dispose();

--- a/packages/web/src/web-terminal.ts
+++ b/packages/web/src/web-terminal.ts
@@ -27,6 +27,8 @@ import { AccessibilityManager } from "./accessibility.js";
 import type { ITerminalAddon } from "./addon.js";
 import { calculateFit } from "./fit.js";
 import { InputHandler } from "./input-handler.js";
+import type { ParserChannel, ParserPool } from "./parser-pool.js";
+import type { FlushMessage } from "./parser-worker.js";
 import { canUseOffscreenCanvas, RenderBridge } from "./render-bridge.js";
 import type { HighlightRange, IRenderer, RendererOptions } from "./renderer.js";
 import { Canvas2DRenderer } from "./renderer.js";
@@ -92,6 +94,12 @@ export interface WebTerminalOptions {
    * - `'main'`: always render on the main thread.
    */
   renderMode?: "auto" | "offscreen" | "main";
+  /**
+   * When provided, the terminal acquires a channel from this shared parser
+   * worker pool instead of spawning its own Worker. Requires `paneId`.
+   * Ignored when `useWorker` is `false`.
+   */
+  parserPool?: ParserPool;
   onData?: (data: Uint8Array) => void;
   onResize?: (size: { cols: number; rows: number }) => void;
   onTitleChange?: (title: string) => void;
@@ -140,8 +148,12 @@ export class WebTerminal {
   private sharedContext: SharedWebGLContext | null = null;
   /** Pane ID within the SharedWebGLContext. */
   private paneId: string | null = null;
-  /** WorkerBridge when using off-thread parsing, null otherwise. */
+  /** WorkerBridge when using off-thread parsing (single-terminal mode), null otherwise. */
   private workerBridge: WorkerBridge | null = null;
+  /** ParserChannel when using a shared parser pool, null otherwise. */
+  private parserChannel: ParserChannel | null = null;
+  /** Reference to the shared parser pool (so releaseChannel can be called on dispose). */
+  private parserPool: ParserPool | null = null;
   /** RenderBridge when using off-thread rendering, null otherwise. */
   private renderBridge: RenderBridge | null = null;
   /** Whether the worker mode is active. */
@@ -199,6 +211,9 @@ export class WebTerminal {
 
     // Determine whether to use the worker.
     this.useWorkerMode = options?.useWorker ?? SAB_AVAILABLE;
+
+    // Store parser pool reference (used in startWorkerMode).
+    this.parserPool = options?.parserPool ?? null;
 
     // Determine render mode.
     const renderMode = options?.renderMode ?? "auto";
@@ -391,107 +406,110 @@ export class WebTerminal {
   // Worker management
   // -----------------------------------------------------------------------
 
+  /** Shared onFlush callback for both WorkerBridge and ParserChannel modes. */
+  private makeWorkerFlushHandler(): (isAlternate: boolean, modes: FlushMessage["modes"]) => void {
+    return (isAlternate, modes) => {
+      if (modes) {
+        this.inputHandler.setApplicationCursorKeys(modes.applicationCursorKeys);
+        this.inputHandler.setBracketedPasteMode(modes.bracketedPasteMode);
+        this.inputHandler.setMouseProtocol(modes.mouseProtocol);
+        this.inputHandler.setMouseEncoding(modes.mouseEncoding);
+        this.inputHandler.setSendFocusEvents(modes.sendFocusEvents);
+        this.inputHandler.setKittyFlags(modes.kittyFlags ?? 0);
+        this.applySyncedOutput(modes.syncedOutput ?? false);
+      }
+
+      if (this.pendingResizeCursor && !this.resizeCursorQueued) {
+        this.resizeCursorQueued = true;
+        const saved = this.pendingResizeCursor;
+        queueMicrotask(() => {
+          this.resizeCursorQueued = false;
+          if (this.pendingResizeCursor === saved) {
+            const cursor = this.bufferSet.active.cursor;
+            cursor.row = saved.row;
+            cursor.col = saved.col;
+          }
+        });
+      }
+
+      const altChanged = isAlternate !== this.bufferSet.isAlternate;
+      if (altChanged) {
+        this.bufferSet.setActive(isAlternate);
+
+        const backend = this.workerBridge ?? this.parserChannel;
+        if (backend) {
+          backend.updateGrid(
+            this.bufferSet.normal.grid,
+            this.bufferSet.alternate.grid,
+            this.bufferSet.active.cursor,
+          );
+        }
+
+        this.viewportOffset = 0;
+        this.displayGrid = null;
+
+        this.inputHandler.setGrid(this.bufferSet.active.grid);
+        this.accessibilityManager?.setGrid(
+          this.bufferSet.active.grid,
+          this.bufferSet.active.grid.rows,
+          this.bufferSet.active.grid.cols,
+        );
+      }
+
+      if (this.viewportOffset > 0 && !altChanged) return;
+
+      const { grid, cursor } = this.bufferSet.active;
+      if (this.sharedContext && this.paneId) {
+        this.sharedContext.updateTerminal(this.paneId, grid, cursor);
+      } else if (this.renderBridge) {
+        this.renderBridge.resize(grid.cols, grid.rows, grid.getBuffer() as SharedArrayBuffer);
+      } else {
+        this.renderer.attach(this.canvas, grid, cursor);
+      }
+    };
+  }
+
   private startWorkerMode(cols: number, rows: number, scrollback: number): void {
+    const onFlush = this.makeWorkerFlushHandler();
+    const onError = (message: string) => {
+      console.warn("[WebTerminal] Worker error, falling back to main thread:", message);
+      this.fallbackToMainThread();
+    };
+
     try {
+      // Pool mode: acquire a channel from the shared parser pool.
+      if (this.parserPool && this.paneId) {
+        this.parserChannel = this.parserPool.acquireChannel(
+          this.paneId,
+          this.bufferSet.normal.grid,
+          this.bufferSet.alternate.grid,
+          this.bufferSet.active.cursor,
+          onFlush,
+          onError,
+        );
+        this.parserChannel.start(cols, rows, scrollback);
+        return;
+      }
+
+      // Single-terminal mode: create a dedicated WorkerBridge.
       this.workerBridge = new WorkerBridge(
         this.bufferSet.normal.grid,
         this.bufferSet.alternate.grid,
         this.bufferSet.active.cursor,
-        (isAlternate, modes) => {
-          // Sync parser modes from worker to main-thread InputHandler.
-          // Use ?? defaults for backward compat with cached worker scripts
-          // that may not include kittyFlags/syncedOutput (#7).
-          if (modes) {
-            this.inputHandler.setApplicationCursorKeys(modes.applicationCursorKeys);
-            this.inputHandler.setBracketedPasteMode(modes.bracketedPasteMode);
-            this.inputHandler.setMouseProtocol(modes.mouseProtocol);
-            this.inputHandler.setMouseEncoding(modes.mouseEncoding);
-            this.inputHandler.setSendFocusEvents(modes.sendFocusEvents);
-            this.inputHandler.setKittyFlags(modes.kittyFlags ?? 0);
-
-            this.applySyncedOutput(modes.syncedOutput ?? false);
-          }
-
-          // Restore cursor position adjusted by resize(). The worker's
-          // resize flush sends cursor (0,0) from its fresh BufferSet,
-          // which applyFlush writes after this callback returns.
-          // Keep restoring on every flush until write() clears it —
-          // a stale pre-resize flush may arrive before the resize flush.
-          // Only queue one microtask at a time to avoid unbounded growth.
-          if (this.pendingResizeCursor && !this.resizeCursorQueued) {
-            this.resizeCursorQueued = true;
-            const saved = this.pendingResizeCursor;
-            queueMicrotask(() => {
-              this.resizeCursorQueued = false;
-              if (this.pendingResizeCursor === saved) {
-                const cursor = this.bufferSet.active.cursor;
-                cursor.row = saved.row;
-                cursor.col = saved.col;
-              }
-            });
-          }
-
-          // Sync bufferSet.active so main-thread consumers (resize,
-          // getRowTexts, selection, accessibility) read the correct buffer.
-          // Use setActive() — NOT activateAlternate() which calls
-          // grid.clear() and would destroy SAB data the worker just wrote.
-          const altChanged = isAlternate !== this.bufferSet.isAlternate;
-          if (altChanged) {
-            this.bufferSet.setActive(isAlternate);
-
-            // Retarget WorkerBridge so applyFlush (which runs after this
-            // callback returns) writes cursor and cell data to the correct
-            // buffer.
-            if (this.workerBridge) {
-              this.workerBridge.updateGrid(
-                this.bufferSet.normal.grid,
-                this.bufferSet.alternate.grid,
-                this.bufferSet.active.cursor,
-              );
-            }
-
-            // Alt screen has no scrollback — reset scroll state so
-            // subsequent flushes aren't dropped by the viewportOffset
-            // guard, and getRowTexts reads the live grid.
-            this.viewportOffset = 0;
-            this.displayGrid = null;
-
-            this.inputHandler.setGrid(this.bufferSet.active.grid);
-            this.accessibilityManager?.setGrid(
-              this.bufferSet.active.grid,
-              this.bufferSet.active.grid.rows,
-              this.bufferSet.active.grid.cols,
-            );
-          }
-
-          // #151: When the user is scrolled back, skip renderer re-attach
-          // for normal data flushes — but always re-attach on buffer switch
-          // so the renderer shows the correct buffer (#4).
-          if (this.viewportOffset > 0 && !altChanged) return;
-
-          const { grid, cursor } = this.bufferSet.active;
-          if (this.sharedContext && this.paneId) {
-            this.sharedContext.updateTerminal(this.paneId, grid, cursor);
-          } else if (this.renderBridge) {
-            this.renderBridge.resize(grid.cols, grid.rows, grid.getBuffer() as SharedArrayBuffer);
-          } else {
-            this.renderer.attach(this.canvas, grid, cursor);
-          }
-        },
-        (message: string) => {
-          // On worker error, fall back to main-thread parsing.
-          console.warn("[WebTerminal] Worker error, falling back to main thread:", message);
-          this.fallbackToMainThread();
-        },
+        onFlush,
+        onError,
       );
       this.workerBridge.start(cols, rows, scrollback);
     } catch {
-      // Worker could not be created — fall back silently.
       this.fallbackToMainThread();
     }
   }
 
   private fallbackToMainThread(): void {
+    if (this.parserChannel && this.parserPool && this.paneId) {
+      this.parserPool.releaseChannel(this.paneId);
+      this.parserChannel = null;
+    }
     if (this.workerBridge) {
       this.workerBridge.dispose();
       this.workerBridge = null;
@@ -585,7 +603,9 @@ export class WebTerminal {
 
     const bytes = typeof data === "string" ? this.encoder.encode(data) : data;
 
-    if (this.workerBridge) {
+    if (this.parserChannel) {
+      this.parserChannel.write(bytes);
+    } else if (this.workerBridge) {
       this.workerBridge.write(bytes);
     } else if (this.parser) {
       this.parser.write(bytes);
@@ -848,17 +868,18 @@ export class WebTerminal {
     }
 
     this.bufferSet.active.grid.markAllDirty();
-    if (this.workerBridge) {
+    const backend = this.parserChannel ?? this.workerBridge;
+    if (backend) {
       // Save adjusted cursor — the worker's resize flush will send
       // cursor (0,0) from its fresh BufferSet, overwriting ours.
       this.pendingResizeCursor = { row: finalCursor.row, col: finalCursor.col };
-      // Update the bridge's grid reference and notify the worker.
-      this.workerBridge.updateGrid(
+      // Update the backend's grid reference and notify the worker.
+      backend.updateGrid(
         this.bufferSet.normal.grid,
         this.bufferSet.alternate.grid,
         this.bufferSet.active.cursor,
       );
-      this.workerBridge.resize(cols, rows, scrollback, finalCursor.row, finalCursor.col);
+      backend.resize(cols, rows, scrollback, finalCursor.row, finalCursor.col);
     } else {
       this.parser = new VTParser(this.bufferSet);
       this.parser.setTitleChangeCallback((title: string) => {
@@ -1285,6 +1306,10 @@ export class WebTerminal {
       this.paneId = null;
     }
 
+    if (this.parserChannel && this.parserPool && this.paneId) {
+      this.parserPool.releaseChannel(this.paneId);
+      this.parserChannel = null;
+    }
     if (this.workerBridge) {
       this.workerBridge.dispose();
       this.workerBridge = null;

--- a/packages/web/src/worker-bridge.ts
+++ b/packages/web/src/worker-bridge.ts
@@ -17,14 +17,14 @@ import type { FlushMessage, OutboundMessage } from "./parser-worker.js";
 // ---- Flow-control constants ------------------------------------------------
 
 /** Pause sending new writes when pending bytes exceed this threshold. */
-const HIGH_WATERMARK = 2 * 1024 * 1024; // 2 MB
+export const HIGH_WATERMARK = 2 * 1024 * 1024; // 2 MB
 
 /** Resume sending when pending bytes drop below this threshold. */
-const LOW_WATERMARK = 512 * 1024; // 512 KB
+export const LOW_WATERMARK = 512 * 1024; // 512 KB
 
 // ---- Feature detection -----------------------------------------------------
 
-const SAB_AVAILABLE =
+export const SAB_AVAILABLE =
   typeof SharedArrayBuffer !== "undefined" &&
   (typeof crossOriginIsolated !== "undefined" ? crossOriginIsolated : true);
 


### PR DESCRIPTION
## Summary

- **Zero-copy worker transfer**: `subarray()`/offset views had `byteOffset != 0`, forcing every write through the slow `buffer.slice()` copy path in the worker bridge. Fixed in both comparison mux-client and e2e-bench MuxBenchmarkRunner by using `slice()` to create owned buffers.
- **Metrics recording fix**: `byteLength` returns 0 after an ArrayBuffer is transferred (detached). Captured length before `write()` in comparison page and both multi-pane benchmark runners.
- **PTY server output coalescing**: 4ms coalescing window batches many small PTY callbacks into fewer, larger WebSocket frames. Faster workloads (`cat|xxd`, `awk` instead of shell fork loops).
- **Demo fixes**: renamed misleading "FPS" → "Page FPS" in metrics panel; fixed wsRef clobber race on overlapping close/connect; fixed arrow keys leaking `[A`/`[B` bracket chars into local echo.

## Benchmark results (8-pane mux, sgr-color)

| Metric | react-term | xterm.js | Factor |
|--------|-----------|----------|--------|
| Throughput | **130 MB/s** | 14 MB/s | 9.3x |
| Total time | **324 ms** | 3,024 ms | 9.3x |
| Frame p99 | **9.3 ms** | 24.5 ms | 2.6x |
| setTimeout max | **8.5 ms** | 34.4 ms | 4.1x |

## Test plan

- [x] `pnpm test` — 1752 tests pass
- [x] E2E mux benchmark runs successfully with Playwright
- [ ] CI benchmark action validates numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)