### PR TITLE
feat: terminal state save/restore (serialize / hydrate / initialState)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,5 +25,5 @@ export type {
   TerminalState,
   Theme,
 } from "./types.js";
-export { DEFAULT_THEME, DirtyState } from "./types.js";
+export { DEFAULT_THEME, DirtyState, SNAPSHOT_VERSION } from "./types.js";
 export { isCombining, wcwidth } from "./wcwidth.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,13 @@ export { VTParser } from "./parser/index.js";
 export { Action, State, TABLE, unpackAction, unpackState } from "./parser/states.js";
 export type { ReflowResult, RowData } from "./reflow.js";
 export { MAX_LOGICAL_LINE_LEN, reflowRows } from "./reflow.js";
-export type { CursorState, SelectionState, TerminalOptions, Theme } from "./types.js";
+export type {
+  CursorState,
+  ParserModeState,
+  SelectionState,
+  TerminalOptions,
+  TerminalState,
+  Theme,
+} from "./types.js";
 export { DEFAULT_THEME, DirtyState } from "./types.js";
 export { isCombining, wcwidth } from "./wcwidth.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -13,6 +13,57 @@ export interface CursorState {
   wrapPending: boolean;
 }
 
+/**
+ * DEC private-mode + mouse state that's sticky across output (i.e. not reset
+ * between writes). Surfaced for save/restore so a remounted terminal reacts
+ * to keyboard/mouse the same way the old one did.
+ */
+export interface ParserModeState {
+  readonly applicationCursorKeys: boolean;
+  readonly bracketedPasteMode: boolean;
+  readonly mouseProtocol: import("./parser/index.js").MouseProtocol;
+  readonly mouseEncoding: import("./parser/index.js").MouseEncoding;
+  readonly sendFocusEvents: boolean;
+}
+
+/**
+ * Serialized terminal state for save/restore scenarios (e.g. remount without
+ * losing grid content, cursor, scrollback, or parser modes). Treat the shape
+ * as opaque — pass it from `serialize()` back into `hydrate()` or
+ * `initialState` without inspecting internals.
+ *
+ * Captures the active buffer only — the inactive normal/alternate buffer is
+ * not serialized. Intended for fast remount of the visible buffer; callers
+ * that need full dual-buffer restore should maintain their own snapshot.
+ *
+ * In worker-mode terminals, scrollback lives in the parser worker and is not
+ * reachable from the main thread — `scrollback` will be empty in that mode.
+ * Callers that drive a server-side snapshot replay typically don't need it.
+ */
+export interface TerminalState {
+  /** Bumped if the schema changes so callers can detect incompatible snapshots. */
+  readonly version: 1;
+  readonly cols: number;
+  readonly rows: number;
+  /** Active grid cell data in full format: length === rows * cols * CELL_SIZE. */
+  readonly cells: Uint32Array;
+  /** One Int32 per row (0 or 1) indicating soft-wrap. */
+  readonly wrapFlags: Int32Array;
+  readonly cursor: {
+    readonly row: number;
+    readonly col: number;
+    readonly visible: boolean;
+    readonly style: "block" | "underline" | "bar";
+  };
+  readonly scrollback: {
+    readonly rows: readonly Uint32Array[];
+    readonly wrap: readonly boolean[];
+    readonly compact: readonly boolean[];
+  };
+  readonly parserModes: ParserModeState;
+  readonly isAlternate: boolean;
+}
+
 export interface TerminalOptions {
   cols: number;
   rows: number;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -27,6 +27,13 @@ export interface ParserModeState {
 }
 
 /**
+ * Schema version for `TerminalState`. Bumped when the shape changes
+ * incompatibly. The literal type on `TerminalState.version` is derived from
+ * this so the runtime check and the compile-time guarantee can't drift.
+ */
+export const SNAPSHOT_VERSION = 1 as const;
+
+/**
  * Serialized terminal state for save/restore scenarios (e.g. remount without
  * losing grid content, cursor, scrollback, or parser modes). Treat the shape
  * as opaque — pass it from `serialize()` back into `hydrate()` or
@@ -42,7 +49,7 @@ export interface ParserModeState {
  */
 export interface TerminalState {
   /** Bumped if the schema changes so callers can detect incompatible snapshots. */
-  readonly version: 1;
+  readonly version: typeof SNAPSHOT_VERSION;
   readonly cols: number;
   readonly rows: number;
   /** Active grid cell data in full format: length === rows * cols * CELL_SIZE. */

--- a/packages/demo/src/main.tsx
+++ b/packages/demo/src/main.tsx
@@ -5,12 +5,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 
 // ---------------------------------------------------------------------------
-// Snapshot persistence helpers
-//
-// `TerminalState` contains typed arrays (Uint32Array, Int32Array) that don't
-// JSON-serialize natively. Convert to plain arrays for storage and rebuild
-// the typed arrays on read. Encoded form is verbose but trivially correct;
-// for production use you'd want base64 + ArrayBuffer.
+// Snapshot persistence helpers — JSON-safe encoding for localStorage demo use.
+// (TerminalState's typed arrays don't JSON-serialize natively.)
 // ---------------------------------------------------------------------------
 
 const STORAGE_KEY = "next_term_demo_snapshot_v1";

--- a/packages/demo/src/main.tsx
+++ b/packages/demo/src/main.tsx
@@ -1,8 +1,71 @@
-import type { Theme } from "@next_term/core";
+import type { TerminalState, Theme } from "@next_term/core";
 import type { PaneLayout, TerminalHandle, TerminalPaneHandle } from "@next_term/react";
 import { Terminal, TerminalPane } from "@next_term/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
+
+// ---------------------------------------------------------------------------
+// Snapshot persistence helpers
+//
+// `TerminalState` contains typed arrays (Uint32Array, Int32Array) that don't
+// JSON-serialize natively. Convert to plain arrays for storage and rebuild
+// the typed arrays on read. Encoded form is verbose but trivially correct;
+// for production use you'd want base64 + ArrayBuffer.
+// ---------------------------------------------------------------------------
+
+const STORAGE_KEY = "next_term_demo_snapshot_v1";
+
+interface StoredSnapshot {
+  version: 1;
+  cols: number;
+  rows: number;
+  cells: number[];
+  wrapFlags: number[];
+  cursor: TerminalState["cursor"];
+  scrollback: {
+    rows: number[][];
+    wrap: boolean[];
+    compact: boolean[];
+  };
+  parserModes: TerminalState["parserModes"];
+  isAlternate: boolean;
+}
+
+function snapshotToStorage(s: TerminalState): StoredSnapshot {
+  return {
+    version: 1,
+    cols: s.cols,
+    rows: s.rows,
+    cells: Array.from(s.cells),
+    wrapFlags: Array.from(s.wrapFlags),
+    cursor: s.cursor,
+    scrollback: {
+      rows: s.scrollback.rows.map((r) => Array.from(r)),
+      wrap: [...s.scrollback.wrap],
+      compact: [...s.scrollback.compact],
+    },
+    parserModes: s.parserModes,
+    isAlternate: s.isAlternate,
+  };
+}
+
+function storageToSnapshot(s: StoredSnapshot): TerminalState {
+  return {
+    version: 1,
+    cols: s.cols,
+    rows: s.rows,
+    cells: new Uint32Array(s.cells),
+    wrapFlags: new Int32Array(s.wrapFlags),
+    cursor: s.cursor,
+    scrollback: {
+      rows: s.scrollback.rows.map((r) => new Uint32Array(r)),
+      wrap: s.scrollback.wrap,
+      compact: s.scrollback.compact,
+    },
+    parserModes: s.parserModes,
+    isAlternate: s.isAlternate,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Themes
@@ -218,14 +281,30 @@ function useFps() {
 function HUD({
   isDark,
   onToggleTheme,
+  onSave,
+  onRestore,
+  hasSnapshot,
   fps,
   status,
 }: {
   isDark: boolean;
   onToggleTheme: () => void;
+  onSave: () => void;
+  onRestore: () => void;
+  hasSnapshot: boolean;
   fps: number;
   status: ConnectionStatus;
 }) {
+  const btnStyle = {
+    background: isDark ? "#333" : "#ddd",
+    color: isDark ? "#eee" : "#222",
+    border: "none",
+    borderRadius: 4,
+    padding: "2px 8px",
+    cursor: "pointer",
+    fontSize: 11,
+    fontFamily: "inherit",
+  };
   return (
     <div
       style={{
@@ -257,18 +336,26 @@ function HUD({
         </span>
         <button
           type="button"
-          onClick={onToggleTheme}
-          style={{
-            background: isDark ? "#333" : "#ddd",
-            color: isDark ? "#eee" : "#222",
-            border: "none",
-            borderRadius: 4,
-            padding: "2px 8px",
-            cursor: "pointer",
-            fontSize: 11,
-            fontFamily: "inherit",
-          }}
+          onClick={onSave}
+          style={btnStyle}
+          title="Snapshot terminal to localStorage"
         >
+          Save
+        </button>
+        <button
+          type="button"
+          onClick={onRestore}
+          disabled={!hasSnapshot}
+          style={{
+            ...btnStyle,
+            opacity: hasSnapshot ? 1 : 0.4,
+            cursor: hasSnapshot ? "pointer" : "not-allowed",
+          }}
+          title={hasSnapshot ? "Hydrate terminal from saved snapshot" : "No snapshot saved yet"}
+        >
+          Restore
+        </button>
+        <button type="button" onClick={onToggleTheme} style={btnStyle}>
           {isDark ? "Light" : "Dark"}
         </button>
       </div>
@@ -290,6 +377,42 @@ function App() {
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const _themeCallbackRef = useRef<((dark: boolean) => void) | null>(null);
   const fps = useFps();
+  const [hasSnapshot, setHasSnapshot] = useState(() => localStorage.getItem(STORAGE_KEY) !== null);
+
+  // Save: snapshot the terminal and persist to localStorage.
+  const handleSave = useCallback(() => {
+    const term = termRef.current;
+    if (!term?.serialize) return;
+    try {
+      const state = term.serialize();
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshotToStorage(state)));
+      setHasSnapshot(true);
+      term.write("\r\n\x1b[1;32m[demo]\x1b[0m terminal state saved to localStorage\r\n");
+      term.write(PROMPT);
+      lineBufferRef.current = "";
+    } catch (err) {
+      console.error("save failed:", err);
+      term.write(`\r\n\x1b[1;31m[demo]\x1b[0m save failed: ${err}\r\n${PROMPT}`);
+    }
+  }, []);
+
+  // Restore: hydrate the live terminal from the saved snapshot. Dimensions
+  // must match — if the window was resized between save and restore, this
+  // will console.warn and bail (which is the intended hydrate() behavior).
+  const handleRestore = useCallback(() => {
+    const term = termRef.current;
+    if (!term?.hydrate) return;
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    try {
+      const stored = JSON.parse(raw) as StoredSnapshot;
+      term.hydrate(storageToSnapshot(stored));
+      lineBufferRef.current = "";
+    } catch (err) {
+      console.error("restore failed:", err);
+      term.write(`\r\n\x1b[1;31m[demo]\x1b[0m restore failed: ${err}\r\n${PROMPT}`);
+    }
+  }, []);
 
   const theme = useMemo(() => (isDark ? DARK_THEME : LIGHT_THEME), [isDark]);
 
@@ -496,7 +619,15 @@ function App() {
         overflow: "hidden",
       }}
     >
-      <HUD isDark={isDark} onToggleTheme={toggleTheme} fps={fps} status={connStatus} />
+      <HUD
+        isDark={isDark}
+        onToggleTheme={toggleTheme}
+        onSave={handleSave}
+        onRestore={handleRestore}
+        hasSnapshot={hasSnapshot}
+        fps={fps}
+        status={connStatus}
+      />
       <Terminal
         ref={termRef}
         autoFit

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -151,8 +151,84 @@ interface TerminalHandle {
   focus(): void;
   blur(): void;
   fit(): void;
+  // Save / restore — see "Save and restore" below.
+  serialize?(): TerminalState;
+  hydrate?(state: TerminalState): void;
+  getParserModes?(): ParserModeState;
+  setParserModes?(modes: ParserModeState): void;
 }
 ```
+
+## Save and restore
+
+`<Terminal>` can capture its current state (grid contents, cursor, scrollback,
+active buffer, parser modes) and restore it onto a freshly-mounted instance.
+Use this when you reparent the terminal across a layout change (tabs, splits,
+dialog open/close) and want to avoid a blank flash.
+
+### Quick start
+
+```tsx
+import { Terminal } from "@next_term/react";
+import type { TerminalHandle, TerminalState } from "@next_term/react";
+import { useRef, useState } from "react";
+
+function Saveable() {
+  const ref = useRef<TerminalHandle>(null);
+  const [snapshot, setSnapshot] = useState<TerminalState>();
+
+  return (
+    <>
+      <button onClick={() => setSnapshot(ref.current?.serialize?.())}>Save</button>
+      {snapshot && (
+        // Remount with `initialState`. The first paint shows the restored
+        // grid — no blank-then-fill flash.
+        <Terminal ref={ref} cols={80} rows={24} initialState={snapshot} />
+      )}
+    </>
+  );
+}
+```
+
+### Two ways in
+
+| API | When |
+|---|---|
+| `initialState` prop on `<Terminal>` | First mount. Applied **before** the render loop or parser worker starts — guarantees a blank frame is never shown. |
+| `hydrate(state)` imperative method | Already-mounted terminal. Useful for "undo" / "switch session" / live restore. Routes through the parser worker so in-flight writes are preserved (FIFO). |
+
+### Dimensions must match
+
+`hydrate()` no-ops with a `console.warn` if `state.cols`/`state.rows` differ
+from the live terminal. Either resize the terminal first or capture a fresh
+snapshot at the new size.
+
+### Worker-mode caveat
+
+In worker mode (the default when `crossOriginIsolated` is true) the parser
+worker owns the scrollback. The snapshot's `scrollback` field will be empty;
+restoring still recovers the active grid and cursor. If you need server-side
+replay of scrollback, drive it through `write()` after hydrate.
+
+### Snapshot shape
+
+```ts
+interface TerminalState {
+  version: 1;                       // bumped on schema break
+  cols: number;
+  rows: number;
+  cells: Uint32Array;               // active grid, 4 × u32 per cell
+  wrapFlags: Int32Array;            // 1 per row (soft-wrap flag)
+  cursor: { row, col, visible, style };
+  scrollback: { rows, wrap, compact };
+  parserModes: ParserModeState;     // app-cursor, bracketed paste, mouse, etc.
+  isAlternate: boolean;             // alt buffer flag (vim/htop etc.)
+}
+```
+
+Treat as opaque: pass it from `serialize()` to `hydrate()` / `initialState`
+without inspecting it. To persist across reloads, convert the typed arrays to
+plain arrays before `JSON.stringify` (see the demo for a reference helper).
 
 ## Best Practices
 

--- a/packages/react/src/Terminal.tsx
+++ b/packages/react/src/Terminal.tsx
@@ -1,4 +1,4 @@
-import type { MouseEncoding, MouseProtocol, Theme } from "@next_term/core";
+import type { ParserModeState, TerminalState, Theme } from "@next_term/core";
 import type { ParserPool, SharedContext } from "@next_term/web";
 import { calculateFit, WebTerminal } from "@next_term/web";
 import type React from "react";
@@ -34,6 +34,12 @@ export interface TerminalProps {
   paneId?: string;
   /** Shared parser worker pool for multi-pane parsing. */
   parserPool?: ParserPool;
+  /**
+   * Snapshot captured from a previous terminal via `serialize()`. Restored
+   * before the first frame is painted — useful for fast remount without a
+   * blank flash (e.g. when reparenting panes in a tab/split layout).
+   */
+  initialState?: TerminalState;
 }
 
 export interface TerminalHandle {
@@ -49,15 +55,15 @@ export interface TerminalHandle {
   /** Whether the alternate buffer is active (vim, htop, etc.). */
   readonly isAlternateBuffer?: boolean;
   /** Get current parser/input mode state for save/restore. */
-  getParserModes?(): {
-    applicationCursorKeys: boolean;
-    bracketedPasteMode: boolean;
-    mouseProtocol: MouseProtocol;
-    mouseEncoding: MouseEncoding;
-    sendFocusEvents: boolean;
-  };
+  getParserModes?(): ParserModeState;
   /** Current scroll offset (0 = live/bottom, positive = lines scrolled back). */
   readonly scrollOffset?: number;
+  /** Apply parser/input modes. See `WebTerminal.setParserModes` for caveats. */
+  setParserModes?(modes: ParserModeState): void;
+  /** Capture a snapshot of the active buffer + cursor + scrollback + parser modes. */
+  serialize?(): TerminalState;
+  /** Apply a snapshot produced by `serialize()`. Dimensions must match. */
+  hydrate?(state: TerminalState): void;
 }
 
 export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Terminal(props, ref) {
@@ -82,6 +88,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     sharedContext,
     paneId,
     parserPool,
+    initialState,
   } = props;
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -156,11 +163,34 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
           };
         return terminal.getParserModes();
       },
+      setParserModes(modes) {
+        termRef.current?.setParserModes(modes);
+      },
+      serialize() {
+        const terminal = termRef.current;
+        if (!terminal) {
+          throw new Error("[Terminal] serialize() called before terminal is mounted");
+        }
+        return terminal.serialize();
+      },
+      hydrate(state) {
+        const terminal = termRef.current;
+        if (!terminal) {
+          throw new Error("[Terminal] hydrate() called before terminal is mounted");
+        }
+        terminal.hydrate(state);
+      },
     }),
     [],
   );
 
-  // Initialize WebTerminal on mount (handles StrictMode double-mount)
+  // Initialize WebTerminal on mount (handles StrictMode double-mount).
+  // `initialState` is intentionally NOT in the deps array — it's an
+  // apply-once-on-mount snapshot; reapplying it on every snapshot identity
+  // change would defeat its purpose (a stable "restore the previous session"
+  // input, not a controlled value). Callers needing dynamic restore can call
+  // the imperative `hydrate()` method instead.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: initialState is apply-once on mount
   useEffect(() => {
     if (initialized.current) return;
     initialized.current = true;
@@ -183,6 +213,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       sharedContext,
       paneId,
       parserPool,
+      initialState,
       onData: (data: Uint8Array) => onDataRef.current?.(data),
       onResize: (size: { cols: number; rows: number }) => onResizeRef.current?.(size),
       onTitleChange: (title: string) => onTitleChangeRef.current?.(title),

--- a/packages/react/src/__tests__/terminal-hydrate.test.ts
+++ b/packages/react/src/__tests__/terminal-hydrate.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+/**
+ * Integration test for the React <Terminal> imperative handle's
+ * serialize()/hydrate() passthrough. Uses React without JSX so the file
+ * can stay .test.ts (the repo's vitest glob doesn't match .tsx).
+ */
+
+import { act, createElement, createRef } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Terminal, type TerminalHandle } from "../Terminal.js";
+
+// Canvas 2D context mock — WebTerminal's renderer needs it under jsdom.
+function createMock2DContext() {
+  return {
+    font: "",
+    setTransform: vi.fn(),
+    clearRect: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    strokeRect: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    rect: vi.fn(),
+    clip: vi.fn(),
+    measureText: vi.fn((_t: string) => ({
+      width: 8,
+      fontBoundingBoxAscent: 12,
+      fontBoundingBoxDescent: 4,
+    })),
+  };
+}
+
+vi.stubGlobal("Worker", function MockWorker() {
+  return {
+    postMessage: vi.fn(),
+    terminate: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  };
+} as unknown as typeof Worker);
+
+vi.stubGlobal("URL", {
+  createObjectURL: vi.fn(() => "blob:mock"),
+  revokeObjectURL: vi.fn(),
+});
+
+// React 19 scheduler needs IS_REACT_ACT_ENVIRONMENT to silence warnings.
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("<Terminal> ref: serialize/hydrate integration", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+      createMock2DContext() as unknown as CanvasRenderingContext2D,
+    );
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("exposes serialize() / hydrate() on the ref and round-trips state", () => {
+    const ref = createRef<TerminalHandle>();
+    act(() => {
+      root.render(
+        createElement(Terminal, {
+          ref,
+          cols: 20,
+          rows: 4,
+          useWorker: false,
+          renderer: "canvas2d",
+          renderMode: "main",
+        }),
+      );
+    });
+
+    const handle = ref.current;
+    expect(handle).not.toBeNull();
+    expect(typeof handle?.serialize).toBe("function");
+    expect(typeof handle?.hydrate).toBe("function");
+    expect(typeof handle?.setParserModes).toBe("function");
+
+    handle?.write("Snapshot me");
+    const state = handle?.serialize?.();
+    expect(state?.cols).toBe(20);
+    expect(state?.rows).toBe(4);
+    expect(state?.cursor.col).toBe(11);
+  });
+
+  it("serialize() throws when called on a mounted-then-unmounted ref", () => {
+    const ref = createRef<TerminalHandle>();
+    act(() => {
+      root.render(
+        createElement(Terminal, {
+          ref,
+          cols: 10,
+          rows: 3,
+          useWorker: false,
+          renderer: "canvas2d",
+          renderMode: "main",
+        }),
+      );
+    });
+    const handle = ref.current;
+    act(() => root.unmount());
+    expect(() => handle?.serialize?.()).toThrow(/before terminal is mounted|after dispose/);
+  });
+
+  it("initialState prop restores cursor + grid before first paint", () => {
+    // Build a snapshot on a throwaway terminal...
+    const sourceRef = createRef<TerminalHandle>();
+    act(() => {
+      root.render(
+        createElement(Terminal, {
+          ref: sourceRef,
+          cols: 15,
+          rows: 3,
+          useWorker: false,
+          renderer: "canvas2d",
+          renderMode: "main",
+        }),
+      );
+    });
+    sourceRef.current?.write("Hello React");
+    const snapshot = sourceRef.current?.serialize?.();
+    expect(snapshot).toBeDefined();
+
+    // ...then remount with initialState; the new terminal must show the text.
+    const targetRef = createRef<TerminalHandle>();
+    act(() => {
+      root.render(
+        createElement(Terminal, {
+          ref: targetRef,
+          cols: 15,
+          rows: 3,
+          useWorker: false,
+          renderer: "canvas2d",
+          renderMode: "main",
+          initialState: snapshot,
+        }),
+      );
+    });
+
+    const rows = targetRef.current?.getRowTexts?.();
+    expect(rows?.[0]?.trim()).toBe("Hello React");
+  });
+});

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -173,6 +173,50 @@ Controls where **rendering** happens (independent of `useWorker` which controls 
 | `false` | VT parser runs on main thread |
 | `undefined` (default) | Auto: uses worker when SharedArrayBuffer is available |
 
+## Save and restore
+
+`WebTerminal` can snapshot the active buffer, cursor, scrollback, and parser
+modes for restoration onto a fresh terminal. Useful for remount-without-flash
+(layout reparenting, tab switching) and session persistence.
+
+### API
+
+```ts
+import type { TerminalState } from "@next_term/web";
+
+const state: TerminalState = terminal.serialize();
+// pass into the constructor (preferred — applies before the first paint)
+new WebTerminal(container, { cols, rows, initialState: state });
+// or onto an already-mounted instance
+terminal.hydrate(state);
+```
+
+| Path | Where it applies | Notes |
+|---|---|---|
+| `initialState` option | First mount, before render worker / parser worker start | No flash. Recommended. |
+| `terminal.hydrate(state)` | Live terminal | Worker-mode routes through the parser worker's FIFO so in-flight `write()`s are preserved. |
+| `terminal.serialize()` | Anywhere except after `dispose()` | Throws after dispose. Returns a versioned `TerminalState`. |
+
+### Worker-mode scrollback
+
+In worker mode the parser worker owns scrollback. `serialize()` returns it
+empty (`scrollback.rows.length === 0`); the active grid + cursor + modes still
+round-trip. Drive scrollback replay through `write()` after hydrate if needed.
+
+### Validation
+
+`hydrate()` and the constructor's `initialState` both validate the snapshot
+shape (version, dimensions, cell-data length, scrollback array parity) and
+no-op with a `console.warn` on mismatch. The terminal remains in its
+fresh / pre-hydrate state.
+
+### Persistence
+
+`TerminalState` contains `Uint32Array`/`Int32Array` which don't `JSON.stringify`
+directly. For localStorage / IndexedDB, convert via `Array.from(...)` on save
+and rebuild the typed arrays on load — see `packages/demo/src/main.tsx` for
+a working example. Base64 is more compact for large terminals.
+
 ## Best Practices
 
 ### SharedWebGLContext Viewport Coordinates
@@ -245,7 +289,13 @@ export { calculateFit, InputHandler, WorkerBridge, RenderBridge } from "@next_te
 export { AccessibilityManager, GlyphAtlas, hexToFloat4 } from "@next_term/web";
 
 // Re-exported from @next_term/core
-export type { Theme, CursorState, TerminalOptions } from "@next_term/web";
+export type {
+  Theme,
+  CursorState,
+  TerminalOptions,
+  TerminalState,
+  ParserModeState,
+} from "@next_term/web";
 export { DEFAULT_THEME, CellGrid } from "@next_term/web";
 ```
 

--- a/packages/web/src/__tests__/parser-pool.test.ts
+++ b/packages/web/src/__tests__/parser-pool.test.ts
@@ -1,5 +1,5 @@
-import type { CursorState } from "@next_term/core";
-import { CellGrid } from "@next_term/core";
+import type { CursorState, ParserModeState } from "@next_term/core";
+import { CELL_SIZE, CellGrid } from "@next_term/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ParserPool } from "../parser-pool.js";
 import type { FlushMessage } from "../parser-worker.js";
@@ -565,6 +565,120 @@ describe("ParserChannel", () => {
       const fresh = pool.acquireChannel("c1", grid, altGrid, makeCursor(), () => {});
       fresh.start(80, 24, 100);
     }).not.toThrow();
+
+    pool.dispose();
+  });
+
+  // ---- seed --------------------------------------------------------------
+
+  it("seed() without cellData posts a tagged seed message and zero transferables", () => {
+    // Pre-write seed path: cursor + modes + active-buffer only. This is the
+    // shape used by the `initialState` constructor option in SAB mode, where
+    // the main thread has already written cells to the shared buffer.
+    const pool = new ParserPool(1);
+    const { grid, altGrid } = makeGrids();
+    const channel = pool.acquireChannel("c1", grid, altGrid, makeCursor(), () => {});
+    channel.start(80, 24, 100);
+
+    const modes: ParserModeState = {
+      applicationCursorKeys: true,
+      bracketedPasteMode: false,
+      mouseProtocol: "none",
+      mouseEncoding: "default",
+      sendFocusEvents: false,
+    };
+    channel.seed({ row: 5, col: 3, visible: true, style: "block" }, false, modes);
+
+    const seedCalls = createdWorkers[0].postMessage.mock.calls.filter((c) => c[0]?.type === "seed");
+    expect(seedCalls).toHaveLength(1);
+    expect(seedCalls[0][0]).toMatchObject({
+      type: "seed",
+      channelId: "c1",
+      cursor: { row: 5, col: 3, visible: true, style: "block" },
+      isAlternate: false,
+      modes,
+    });
+    expect(seedCalls[0][0].cellData).toBeUndefined();
+    expect(seedCalls[0][0].wrapFlags).toBeUndefined();
+    expect(seedCalls[0][1] ?? []).toEqual([]);
+
+    pool.dispose();
+  });
+
+  it("seed() with cellData + wrapFlags ships both as transferables", () => {
+    // Post-construction hydrate path: main thread needs cells to reach the
+    // worker via postMessage so the write FIFO is respected (no SAB race).
+    const pool = new ParserPool(1);
+    const { grid, altGrid } = makeGrids();
+    const channel = pool.acquireChannel("c1", grid, altGrid, makeCursor(), () => {});
+    channel.start(80, 24, 100);
+
+    const cells = new ArrayBuffer(80 * 24 * CELL_SIZE * 4);
+    const wrap = new ArrayBuffer(24 * 4);
+    const modes: ParserModeState = {
+      applicationCursorKeys: false,
+      bracketedPasteMode: false,
+      mouseProtocol: "none",
+      mouseEncoding: "default",
+      sendFocusEvents: false,
+    };
+    channel.seed({ row: 0, col: 0, visible: true, style: "block" }, true, modes, cells, wrap);
+
+    const seedCalls = createdWorkers[0].postMessage.mock.calls.filter((c) => c[0]?.type === "seed");
+    expect(seedCalls).toHaveLength(1);
+    expect(seedCalls[0][0].cellData).toBe(cells);
+    expect(seedCalls[0][0].wrapFlags).toBe(wrap);
+    expect(seedCalls[0][0].isAlternate).toBe(true);
+    expect(seedCalls[0][1]).toEqual([cells, wrap]);
+
+    pool.dispose();
+  });
+
+  it("seed() is deferred behind locally-queued writes and posts after drain (FIFO)", () => {
+    // When the worker is over HIGH_WATERMARK the channel queues writes
+    // locally. A seed arriving during that window must NOT skip the queue —
+    // otherwise the worker would apply hydrated state on top of cells that
+    // hadn't yet streamed through.
+    const pool = new ParserPool(1);
+    const { grid, altGrid } = makeGrids();
+    const channel = pool.acquireChannel("c1", grid, altGrid, makeCursor(), () => {});
+    channel.start(80, 24, 100);
+
+    // Cross HIGH_WATERMARK and queue a small follow-up write.
+    channel.write(new Uint8Array(3 * 1024 * 1024));
+    channel.write(new Uint8Array([65, 66, 67]));
+    expect(channel.isPaused).toBe(true);
+
+    const modes: ParserModeState = {
+      applicationCursorKeys: false,
+      bracketedPasteMode: false,
+      mouseProtocol: "none",
+      mouseEncoding: "default",
+      sendFocusEvents: false,
+    };
+    channel.seed({ row: 1, col: 2, visible: true, style: "block" }, false, modes);
+
+    // Seed has NOT been posted yet — it's deferred behind the queued write.
+    let seeds = createdWorkers[0].postMessage.mock.calls.filter((c) => c[0]?.type === "seed");
+    expect(seeds).toHaveLength(0);
+
+    // Drain the worker below LOW_WATERMARK → queued write goes out, then seed.
+    createdWorkers[0].simulateMessage({
+      type: "flush",
+      channelId: "c1",
+      cursor: { row: 0, col: 0, visible: true, style: "block" },
+      isAlternate: false,
+      bytesProcessed: 3 * 1024 * 1024,
+      modes: DEFAULT_MODES,
+    });
+
+    seeds = createdWorkers[0].postMessage.mock.calls.filter((c) => c[0]?.type === "seed");
+    expect(seeds).toHaveLength(1);
+
+    // FIFO check: the deferred write was posted strictly before the seed.
+    const types = createdWorkers[0].postMessage.mock.calls.map((c) => c[0]?.type);
+    expect(types.lastIndexOf("write")).toBeGreaterThan(-1);
+    expect(types.indexOf("seed")).toBeGreaterThan(types.lastIndexOf("write"));
 
     pool.dispose();
   });

--- a/packages/web/src/__tests__/terminal-state.test.ts
+++ b/packages/web/src/__tests__/terminal-state.test.ts
@@ -1,0 +1,527 @@
+// @vitest-environment jsdom
+/**
+ * serialize() / hydrate() / initialState — roundtrip the main-thread state
+ * of a WebTerminal (grid, cursor, scrollback, parser modes, active buffer)
+ * across a fresh terminal instance.
+ *
+ * Worker and offscreen render paths are covered elsewhere; these tests use
+ * the main-thread canvas2d path where grid data is deterministic.
+ */
+
+import { CELL_SIZE, extractText, type TerminalState } from "@next_term/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WebTerminal } from "../web-terminal.js";
+
+function createMock2DContext() {
+  return {
+    font: "",
+    setTransform: vi.fn(),
+    clearRect: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    strokeRect: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    rect: vi.fn(),
+    clip: vi.fn(),
+    measureText: vi.fn((_text: string) => ({
+      width: 8,
+      fontBoundingBoxAscent: 12,
+      fontBoundingBoxDescent: 4,
+    })),
+  };
+}
+
+vi.stubGlobal("Worker", function MockWorker() {
+  return {
+    postMessage: vi.fn(),
+    terminate: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  };
+} as unknown as typeof Worker);
+
+vi.stubGlobal("URL", {
+  createObjectURL: vi.fn(() => "blob:mock"),
+  revokeObjectURL: vi.fn(),
+});
+
+function patchCanvas() {
+  const ctx = createMock2DContext();
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+    ctx as unknown as CanvasRenderingContext2D,
+  );
+}
+
+function make(container: HTMLElement, extra: ConstructorParameters<typeof WebTerminal>[1] = {}) {
+  return new WebTerminal(container, {
+    useWorker: false,
+    renderer: "canvas2d",
+    renderMode: "main",
+    ...extra,
+  });
+}
+
+describe("WebTerminal serialize/hydrate", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    patchCanvas();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  describe("serialize()", () => {
+    it("captures the current grid contents, cursor, and dimensions", () => {
+      const t = make(container, { cols: 20, rows: 5 });
+      t.write("Hello World");
+      const state = t.serialize();
+
+      expect(state.version).toBe(1);
+      expect(state.cols).toBe(20);
+      expect(state.rows).toBe(5);
+      expect(state.cells).toBeInstanceOf(Uint32Array);
+      expect(state.cells.length).toBe(5 * 20 * 4);
+      expect(state.wrapFlags.length).toBe(5);
+      expect(state.cursor.row).toBe(0);
+      expect(state.cursor.col).toBe(11);
+      expect(state.isAlternate).toBe(false);
+
+      t.dispose();
+    });
+
+    it("captures scrollback rows that spill off-screen", () => {
+      const t = make(container, { cols: 10, rows: 2, scrollback: 100 });
+      for (let i = 0; i < 5; i++) t.write(`L${i}\r\n`);
+      const state = t.serialize();
+      expect(state.scrollback.rows.length).toBeGreaterThanOrEqual(3);
+      t.dispose();
+    });
+  });
+
+  describe("hydrate()", () => {
+    it("restores grid text and cursor into a fresh terminal with matching dimensions", () => {
+      const source = make(container, { cols: 20, rows: 5 });
+      source.write("Hello World");
+      const state = source.serialize();
+      source.dispose();
+
+      const fresh = document.createElement("div");
+      document.body.appendChild(fresh);
+      const target = make(fresh, { cols: 20, rows: 5 });
+      target.hydrate(state);
+
+      expect(extractText(target.activeGrid, 0, 0, 0, 10)).toBe("Hello World");
+      expect(target.activeCursor.col).toBe(11);
+      fresh.remove();
+      target.dispose();
+    });
+
+    it("no-ops with a warning when dimensions do not match", () => {
+      const source = make(container, { cols: 20, rows: 5 });
+      source.write("xxx");
+      const state = source.serialize();
+      source.dispose();
+
+      const fresh = document.createElement("div");
+      document.body.appendChild(fresh);
+      const target = make(fresh, { cols: 40, rows: 10 });
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      target.hydrate(state);
+      expect(warn).toHaveBeenCalledOnce();
+      // Target grid is still blank — hydrate bailed out.
+      expect(extractText(target.activeGrid, 0, 0, 0, 39).trim()).toBe("");
+      fresh.remove();
+      target.dispose();
+    });
+  });
+
+  describe("initialState constructor option", () => {
+    it("restores grid and cursor before the first frame", () => {
+      const source = make(container, { cols: 15, rows: 4 });
+      source.write("Greetings");
+      const state = source.serialize();
+      source.dispose();
+
+      const fresh = document.createElement("div");
+      document.body.appendChild(fresh);
+      const target = make(fresh, { cols: 15, rows: 4, initialState: state });
+
+      expect(extractText(target.activeGrid, 0, 0, 0, 8)).toBe("Greetings");
+      expect(target.activeCursor.col).toBe(9);
+      fresh.remove();
+      target.dispose();
+    });
+
+    it("restores parser modes from the snapshot", () => {
+      const source = make(container);
+      source.setParserModes({
+        applicationCursorKeys: true,
+        bracketedPasteMode: true,
+        mouseProtocol: "vt200",
+        mouseEncoding: "sgr",
+        sendFocusEvents: true,
+      });
+      const state = source.serialize();
+      source.dispose();
+
+      const fresh = document.createElement("div");
+      document.body.appendChild(fresh);
+      const target = make(fresh, { initialState: state });
+
+      const modes = target.getParserModes();
+      expect(modes.applicationCursorKeys).toBe(true);
+      expect(modes.bracketedPasteMode).toBe(true);
+      expect(modes.mouseProtocol).toBe("vt200");
+      expect(modes.mouseEncoding).toBe("sgr");
+      expect(modes.sendFocusEvents).toBe(true);
+
+      fresh.remove();
+      target.dispose();
+    });
+
+    it("restores scrollback lines", () => {
+      const source = make(container, { cols: 10, rows: 2, scrollback: 100 });
+      for (let i = 0; i < 5; i++) source.write(`L${i}\r\n`);
+      const state = source.serialize();
+      const sourceSbLen = state.scrollback.rows.length;
+      source.dispose();
+
+      const fresh = document.createElement("div");
+      document.body.appendChild(fresh);
+      const target = make(fresh, { cols: 10, rows: 2, scrollback: 100, initialState: state });
+
+      expect(target.serialize().scrollback.rows.length).toBe(sourceSbLen);
+
+      fresh.remove();
+      target.dispose();
+    });
+  });
+
+  describe("setParserModes()", () => {
+    it("updates all five mode fields on the input handler", () => {
+      const t = make(container);
+      t.setParserModes({
+        applicationCursorKeys: true,
+        bracketedPasteMode: true,
+        mouseProtocol: "any",
+        mouseEncoding: "sgr",
+        sendFocusEvents: true,
+      });
+      const modes = t.getParserModes();
+      expect(modes).toEqual({
+        applicationCursorKeys: true,
+        bracketedPasteMode: true,
+        mouseProtocol: "any",
+        mouseEncoding: "sgr",
+        sendFocusEvents: true,
+      });
+      t.dispose();
+    });
+  });
+
+  // ---- Edge cases --------------------------------------------------------
+
+  describe("structural validation", () => {
+    function makeValidState(cols: number, rows: number): TerminalState {
+      return {
+        version: 1,
+        cols,
+        rows,
+        cells: new Uint32Array(rows * cols * CELL_SIZE),
+        wrapFlags: new Int32Array(rows),
+        cursor: { row: 0, col: 0, visible: true, style: "block" },
+        scrollback: { rows: [], wrap: [], compact: [] },
+        parserModes: {
+          applicationCursorKeys: false,
+          bracketedPasteMode: false,
+          mouseProtocol: "none",
+          mouseEncoding: "default",
+          sendFocusEvents: false,
+        },
+        isAlternate: false,
+      };
+    }
+
+    it("rejects an unknown version", () => {
+      const t = make(container, { cols: 10, rows: 3 });
+      const bad = { ...makeValidState(10, 3), version: 2 as unknown as 1 };
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      t.hydrate(bad);
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn.mock.calls[0][0]).toMatch(/unsupported version/);
+      t.dispose();
+    });
+
+    it("rejects a snapshot with wrong cells length", () => {
+      const t = make(container, { cols: 10, rows: 3 });
+      const bad: TerminalState = { ...makeValidState(10, 3), cells: new Uint32Array(5) };
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      t.hydrate(bad);
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn.mock.calls[0][0]).toMatch(/malformed/);
+      t.dispose();
+    });
+
+    it("rejects a snapshot with desynced scrollback arrays", () => {
+      const t = make(container, { cols: 10, rows: 3 });
+      const bad: TerminalState = {
+        ...makeValidState(10, 3),
+        scrollback: {
+          rows: [new Uint32Array(10 * CELL_SIZE)],
+          wrap: [],
+          compact: [false],
+        },
+      };
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      t.hydrate(bad);
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn.mock.calls[0][0]).toMatch(/scrollback arrays out of sync/);
+      t.dispose();
+    });
+
+    it("rejects an invalid version at construction (leaves fresh BufferSet intact)", () => {
+      const bad = { ...makeValidState(10, 3), version: 99 as unknown as 1 };
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const t = make(container, { cols: 10, rows: 3, initialState: bad });
+      expect(warn).toHaveBeenCalled();
+      // Grid stayed blank; cursor at origin.
+      expect(t.activeCursor.row).toBe(0);
+      expect(t.activeCursor.col).toBe(0);
+      t.dispose();
+    });
+  });
+
+  describe("scrollback integrity", () => {
+    it("deep-copies scrollback rows so mutation of the source grid doesn't corrupt the snapshot", () => {
+      // Fill scrollback to capacity, snapshot, then scroll more rows so
+      // BufferSet's borrowRowBuffer() would recycle the evicted row.
+      const t = make(container, { cols: 10, rows: 2, scrollback: 3 });
+      for (let i = 0; i < 5; i++) t.write(`A${i}\r\n`);
+      const state = t.serialize();
+      const rowsAtSnapshot = state.scrollback.rows.map((r) => new Uint32Array(r));
+      // More writes → scroll → evict and recycle
+      for (let i = 0; i < 5; i++) t.write(`Z${i}\r\n`);
+      // Snapshot rows must not have been overwritten by the recycled buffer.
+      for (let i = 0; i < state.scrollback.rows.length; i++) {
+        expect(state.scrollback.rows[i]).toEqual(rowsAtSnapshot[i]);
+      }
+      t.dispose();
+    });
+  });
+
+  describe("hydrate() viewport reset", () => {
+    it("snaps viewport to live after hydrating a scrolled-back terminal", () => {
+      const t = make(container, { cols: 10, rows: 2, scrollback: 100 });
+      for (let i = 0; i < 10; i++) t.write(`L${i}\r\n`);
+      (t as unknown as { scrollViewport: (n: number) => void }).scrollViewport(5);
+      expect(t.scrollOffset).toBe(5);
+
+      const other = make(container, { cols: 10, rows: 2, scrollback: 100 });
+      other.write("fresh");
+      t.hydrate(other.serialize());
+      expect(t.scrollOffset).toBe(0);
+      other.dispose();
+      t.dispose();
+    });
+  });
+
+  describe("alt-buffer roundtrip", () => {
+    it("preserves isAlternate across hydrate", () => {
+      const source = make(container, { cols: 10, rows: 3 });
+      source.write("\x1b[?1049h"); // enter alt buffer (DECSET 1049)
+      source.write("alt");
+      expect(source.isAlternateBuffer).toBe(true);
+      const state = source.serialize();
+      expect(state.isAlternate).toBe(true);
+      source.dispose();
+
+      const fresh = document.createElement("div");
+      document.body.appendChild(fresh);
+      const target = make(fresh, { cols: 10, rows: 3, initialState: state });
+      expect(target.isAlternateBuffer).toBe(true);
+      expect(extractText(target.activeGrid, 0, 0, 0, 2)).toBe("alt");
+      fresh.remove();
+      target.dispose();
+    });
+  });
+
+  describe("write-after-hydrate", () => {
+    it("continues writing where the snapshot left off", () => {
+      const source = make(container, { cols: 20, rows: 3 });
+      source.write("Hello ");
+      const state = source.serialize();
+      source.dispose();
+
+      const fresh = document.createElement("div");
+      document.body.appendChild(fresh);
+      const target = make(fresh, { cols: 20, rows: 3, initialState: state });
+      target.write("World");
+      expect(extractText(target.activeGrid, 0, 0, 0, 10)).toBe("Hello World");
+      fresh.remove();
+      target.dispose();
+    });
+  });
+
+  describe("worker-mode hydrate routes cells through worker", () => {
+    function makeWorkerMocks() {
+      const postedMessages: Array<{ msg: unknown; transferables: unknown[] }> = [];
+      // NOTE: do NOT convert to an arrow function — `new` requires a real
+      // constructor and arrow functions throw "is not a constructor".
+      // biome-ignore lint/complexity/useArrowFunction: Worker mock needs constructor semantics
+      const MockWorker = function () {
+        return {
+          postMessage: (msg: unknown, transfer?: unknown[]) => {
+            postedMessages.push({ msg, transferables: transfer ?? [] });
+          },
+          terminate: () => {},
+          addEventListener: () => {},
+          removeEventListener: () => {},
+        };
+      } as unknown as typeof Worker;
+      // WorkerBridge.start uses `new URL("./parser-worker.js", import.meta.url)`.
+      // The file-level URL stub is an object, not a constructor — patch it to
+      // a class so the new-expression doesn't throw for these worker tests.
+      vi.stubGlobal(
+        "URL",
+        class {
+          href: string;
+          constructor(path: string, base?: string | URL) {
+            this.href = `${base ?? ""}${path}`;
+          }
+          toString(): string {
+            return this.href;
+          }
+        },
+      );
+      return { postedMessages, MockWorker };
+    }
+
+    it("posts a seed message containing cellData + wrapFlags on post-construction hydrate", () => {
+      const { postedMessages, MockWorker } = makeWorkerMocks();
+      vi.stubGlobal("Worker", MockWorker);
+
+      // Source (non-worker) to produce a snapshot.
+      const source = make(container, { cols: 10, rows: 3 });
+      source.write("abc");
+      const state = source.serialize();
+      source.dispose();
+
+      const fresh = document.createElement("div");
+      document.body.appendChild(fresh);
+      const target = new WebTerminal(fresh, {
+        useWorker: true,
+        renderer: "canvas2d",
+        renderMode: "main",
+        cols: 10,
+        rows: 3,
+      });
+      target.hydrate(state);
+
+      const seedCalls = postedMessages.filter((m) => (m.msg as { type?: string }).type === "seed");
+      expect(seedCalls.length).toBe(1);
+      const seedMsg = seedCalls[0].msg as { cellData?: ArrayBuffer; wrapFlags?: ArrayBuffer };
+      expect(seedMsg.cellData).toBeInstanceOf(ArrayBuffer);
+      expect(seedMsg.wrapFlags).toBeInstanceOf(ArrayBuffer);
+      expect(seedCalls[0].transferables).toHaveLength(2);
+
+      fresh.remove();
+      target.dispose();
+    });
+
+    it("initialState path posts seed WITHOUT cellData (cells already in SAB before worker start)", () => {
+      const { postedMessages, MockWorker } = makeWorkerMocks();
+      vi.stubGlobal("Worker", MockWorker);
+
+      const source = make(container, { cols: 10, rows: 3 });
+      source.write("xyz");
+      const state = source.serialize();
+      source.dispose();
+
+      const fresh = document.createElement("div");
+      document.body.appendChild(fresh);
+      const target = new WebTerminal(fresh, {
+        useWorker: true,
+        renderer: "canvas2d",
+        renderMode: "main",
+        cols: 10,
+        rows: 3,
+        initialState: state,
+      });
+
+      const seedCalls = postedMessages.filter((m) => (m.msg as { type?: string }).type === "seed");
+      expect(seedCalls.length).toBe(1);
+      const seedMsg = seedCalls[0].msg as { cellData?: ArrayBuffer };
+      expect(seedMsg.cellData).toBeUndefined();
+      expect(seedCalls[0].transferables).toEqual([]);
+
+      fresh.remove();
+      target.dispose();
+    });
+  });
+
+  describe("scrollback truncation to smaller maxScrollback", () => {
+    it("keeps only the most recent rows when target maxScrollback < snapshot", () => {
+      const source = make(container, { cols: 10, rows: 2, scrollback: 100 });
+      for (let i = 0; i < 20; i++) source.write(`L${i}\r\n`);
+      const state = source.serialize();
+      expect(state.scrollback.rows.length).toBeGreaterThanOrEqual(15);
+      source.dispose();
+
+      const fresh = document.createElement("div");
+      document.body.appendChild(fresh);
+      // Target has much smaller scrollback budget.
+      const target = make(fresh, { cols: 10, rows: 2, scrollback: 5, initialState: state });
+      const restoredState = target.serialize();
+      expect(restoredState.scrollback.rows.length).toBe(5);
+
+      fresh.remove();
+      target.dispose();
+    });
+  });
+
+  describe("wide-char roundtrip", () => {
+    it("preserves East Asian double-width glyphs across hydrate", () => {
+      const source = make(container, { cols: 20, rows: 3 });
+      // CJK characters are double-width; the parser places a spacer cell
+      // after each so cursor arithmetic accounts for the width.
+      source.write("漢字TEST");
+      const state = source.serialize();
+      source.dispose();
+
+      const fresh = document.createElement("div");
+      document.body.appendChild(fresh);
+      const target = make(fresh, { cols: 20, rows: 3, initialState: state });
+      // Row 0 should still read as the same text (extractText skips spacer cells).
+      expect(extractText(target.activeGrid, 0, 0, 0, 10)).toBe("漢字TEST");
+      fresh.remove();
+      target.dispose();
+    });
+  });
+
+  describe("disposed guards", () => {
+    it("serialize() throws after dispose()", () => {
+      const t = make(container);
+      t.write("x");
+      t.dispose();
+      expect(() => t.serialize()).toThrow(/after dispose/);
+    });
+
+    it("hydrate() is a no-op after dispose()", () => {
+      const source = make(container, { cols: 10, rows: 2 });
+      source.write("hi");
+      const state = source.serialize();
+
+      const t = make(container, { cols: 10, rows: 2 });
+      t.dispose();
+      expect(() => t.hydrate(state)).not.toThrow();
+      source.dispose();
+    });
+  });
+});

--- a/packages/web/src/__tests__/worker-bridge.test.ts
+++ b/packages/web/src/__tests__/worker-bridge.test.ts
@@ -143,6 +143,53 @@ describe("WorkerBridge", () => {
     expect(writeCalls[0][0].type).toBe("write");
   });
 
+  // ---- seed ---------------------------------------------------------------
+
+  it("sends a seed message without cellData for pre-write hydrate", () => {
+    bridge.start(80, 24, 1000);
+    const modes = {
+      applicationCursorKeys: true,
+      bracketedPasteMode: false,
+      mouseProtocol: "none" as const,
+      mouseEncoding: "default" as const,
+      sendFocusEvents: false,
+    };
+    bridge.seed({ row: 5, col: 3, visible: true, style: "block" }, false, modes);
+    const seedCalls = mockWorkerInstance.postMessage.mock.calls.filter(
+      (c) => c[0]?.type === "seed",
+    );
+    expect(seedCalls.length).toBe(1);
+    expect(seedCalls[0][0]).toEqual({
+      type: "seed",
+      cursor: { row: 5, col: 3, visible: true, style: "block" },
+      isAlternate: false,
+      modes,
+    });
+    // No transferables when cellData/wrapFlags are omitted.
+    expect(seedCalls[0][1]).toEqual([]);
+  });
+
+  it("sends a seed message WITH cellData+wrapFlags as transferables for post-write hydrate", () => {
+    bridge.start(80, 24, 1000);
+    const cells = new ArrayBuffer(80 * 24 * CELL_SIZE * 4);
+    const wrap = new ArrayBuffer(24 * 4);
+    const modes = {
+      applicationCursorKeys: false,
+      bracketedPasteMode: false,
+      mouseProtocol: "none" as const,
+      mouseEncoding: "default" as const,
+      sendFocusEvents: false,
+    };
+    bridge.seed({ row: 0, col: 0, visible: true, style: "block" }, true, modes, cells, wrap);
+    const seedCalls = mockWorkerInstance.postMessage.mock.calls.filter(
+      (c) => c[0]?.type === "seed",
+    );
+    expect(seedCalls.length).toBe(1);
+    expect(seedCalls[0][0].cellData).toBe(cells);
+    expect(seedCalls[0][0].wrapFlags).toBe(wrap);
+    expect(seedCalls[0][1]).toEqual([cells, wrap]);
+  });
+
   // ---- resize -------------------------------------------------------------
 
   it("sends a resize message to the worker", () => {
@@ -303,6 +350,42 @@ describe("WorkerBridge", () => {
       bridge.resize(120, 40, 2000);
       expect(bridge.isPaused).toBe(false);
       expect(bridge.pendingByteCount).toBe(0);
+    });
+
+    it("defers seed() behind queued writes and posts it after drain", () => {
+      bridge.start(80, 24, 1000);
+
+      // Fill past HIGH_WATERMARK to trigger pause, then queue a small write.
+      bridge.write(new Uint8Array(2 * 1024 * 1024));
+      bridge.write(new Uint8Array([65, 66, 67]));
+      expect(bridge.isPaused).toBe(true);
+
+      // Seed while queued — should NOT be posted yet.
+      const modes = {
+        applicationCursorKeys: false,
+        bracketedPasteMode: false,
+        mouseProtocol: "none" as const,
+        mouseEncoding: "default" as const,
+        sendFocusEvents: false,
+      };
+      bridge.seed({ row: 3, col: 2, visible: true, style: "block" }, false, modes);
+      expect(
+        mockWorkerInstance.postMessage.mock.calls.filter((c) => c[0]?.type === "seed").length,
+      ).toBe(0);
+
+      // Flush enough to drop below LOW_WATERMARK → queue drains, then seed posts.
+      mockWorkerInstance.simulateMessage({
+        type: "flush",
+        cursor: { row: 0, col: 0, visible: true, style: "block" },
+        isAlternate: false,
+        bytesProcessed: 2 * 1024 * 1024,
+        modes: DEFAULT_MODES,
+      });
+
+      const types = mockWorkerInstance.postMessage.mock.calls.map((c) => c[0]?.type);
+      const lastWriteIdx = types.lastIndexOf("write");
+      const seedIdx = types.indexOf("seed");
+      expect(seedIdx).toBeGreaterThan(lastWriteIdx);
     });
   });
 

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,5 +1,12 @@
 // Re-export types from core so consumers don't need to depend on core directly
-export type { CursorState, SelectionRange, TerminalOptions, Theme } from "@next_term/core";
+export type {
+  CursorState,
+  ParserModeState,
+  SelectionRange,
+  TerminalOptions,
+  TerminalState,
+  Theme,
+} from "@next_term/core";
 export {
   CELL_SIZE,
   CellGrid,

--- a/packages/web/src/parser-pool.ts
+++ b/packages/web/src/parser-pool.ts
@@ -31,6 +31,7 @@
 import type { CursorState, ParserModeState } from "@next_term/core";
 import { CELL_SIZE, type CellGrid, modPositive } from "@next_term/core";
 import type { FlushMessage, OutboundMessage } from "./parser-worker.js";
+import { buildSeedMessage, type SeedCursor, type SeedMessage } from "./seed-message.js";
 import { HIGH_WATERMARK, LOW_WATERMARK, SAB_AVAILABLE } from "./worker-bridge.js";
 
 /** Hard cap on per-channel writeQueue memory when the worker is stalled.
@@ -62,7 +63,7 @@ export class ParserChannel {
    * A later seed replaces an earlier pending one (both are complete
    * snapshots, latest intent wins).
    */
-  private pendingSeed: { msg: Record<string, unknown>; transferables: ArrayBuffer[] } | null = null;
+  private pendingSeed: { msg: SeedMessage; transferables: ArrayBuffer[] } | null = null;
   private skipFlushCellDataCount = 0;
 
   private disposed = false;
@@ -177,35 +178,20 @@ export class ParserChannel {
    * before the worker started. See `WorkerBridge.seed` for rationale.
    */
   seed(
-    cursor: { row: number; col: number; visible: boolean; style: string },
+    cursor: SeedCursor,
     isAlternate: boolean,
     modes: ParserModeState,
     cellData?: ArrayBuffer,
     wrapFlags?: ArrayBuffer,
   ): void {
     if (this.disposed) return;
-    const msg: Record<string, unknown> = {
-      type: "seed",
-      channelId: this.channelId,
-      cursor,
-      isAlternate,
-      modes,
-    };
-    const transferables: ArrayBuffer[] = [];
-    if (cellData) {
-      msg.cellData = cellData;
-      transferables.push(cellData);
-    }
-    if (wrapFlags) {
-      msg.wrapFlags = wrapFlags;
-      transferables.push(wrapFlags);
-    }
+    const built = buildSeedMessage(cursor, isAlternate, modes, cellData, wrapFlags, this.channelId);
     // Preserve FIFO against locally-queued writes for this channel.
     if (this.writeQueue.length > 0) {
-      this.pendingSeed = { msg, transferables };
+      this.pendingSeed = built;
       return;
     }
-    this.poolPost(msg, transferables);
+    this.poolPost(built.msg, built.transferables);
   }
 
   dispose(): void {

--- a/packages/web/src/parser-pool.ts
+++ b/packages/web/src/parser-pool.ts
@@ -28,7 +28,7 @@
  *     reuse) are dropped without polluting flow control.
  */
 
-import type { CursorState } from "@next_term/core";
+import type { CursorState, ParserModeState } from "@next_term/core";
 import { CELL_SIZE, type CellGrid, modPositive } from "@next_term/core";
 import type { FlushMessage, OutboundMessage } from "./parser-worker.js";
 import { HIGH_WATERMARK, LOW_WATERMARK, SAB_AVAILABLE } from "./worker-bridge.js";
@@ -56,6 +56,13 @@ export class ParserChannel {
   private poolPaused = false;
   private writeQueue: Uint8Array[] = [];
   private queuedBytes = 0;
+  /**
+   * Seed posted while this channel's writes are still queued locally. Held
+   * until the write queue drains so the worker sees writes before the seed.
+   * A later seed replaces an earlier pending one (both are complete
+   * snapshots, latest intent wins).
+   */
+  private pendingSeed: { msg: Record<string, unknown>; transferables: ArrayBuffer[] } | null = null;
   private skipFlushCellDataCount = 0;
 
   private disposed = false;
@@ -162,6 +169,45 @@ export class ParserChannel {
     this.poolPost(msg, transferables);
   }
 
+  /**
+   * Seed the channel's worker-side cursor, parser modes, and active buffer
+   * from a snapshot. Supply `cellData`/`wrapFlags` to route grid writes
+   * through the worker's message queue (post-construction hydrate); omit
+   * them when cells have already been written to SAB on the main thread
+   * before the worker started. See `WorkerBridge.seed` for rationale.
+   */
+  seed(
+    cursor: { row: number; col: number; visible: boolean; style: string },
+    isAlternate: boolean,
+    modes: ParserModeState,
+    cellData?: ArrayBuffer,
+    wrapFlags?: ArrayBuffer,
+  ): void {
+    if (this.disposed) return;
+    const msg: Record<string, unknown> = {
+      type: "seed",
+      channelId: this.channelId,
+      cursor,
+      isAlternate,
+      modes,
+    };
+    const transferables: ArrayBuffer[] = [];
+    if (cellData) {
+      msg.cellData = cellData;
+      transferables.push(cellData);
+    }
+    if (wrapFlags) {
+      msg.wrapFlags = wrapFlags;
+      transferables.push(wrapFlags);
+    }
+    // Preserve FIFO against locally-queued writes for this channel.
+    if (this.writeQueue.length > 0) {
+      this.pendingSeed = { msg, transferables };
+      return;
+    }
+    this.poolPost(msg, transferables);
+  }
+
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
@@ -171,6 +217,7 @@ export class ParserChannel {
     this.poolOnChannelDispose(this.channelId);
     this.writeQueue.length = 0;
     this.queuedBytes = 0;
+    this.pendingSeed = null;
   }
 
   get isPaused(): boolean {
@@ -199,6 +246,12 @@ export class ParserChannel {
       if (!next) break;
       this.queuedBytes -= next.byteLength;
       this.sendWrite(next);
+    }
+    // Post any seed deferred under backpressure, now that the queue is drained.
+    if (this.pendingSeed && this.writeQueue.length === 0 && !this.poolPaused) {
+      const { msg, transferables } = this.pendingSeed;
+      this.pendingSeed = null;
+      this.poolPost(msg, transferables);
     }
   }
 

--- a/packages/web/src/parser-worker.ts
+++ b/packages/web/src/parser-worker.ts
@@ -69,7 +69,39 @@ interface DisposeMessage {
   generation?: number;
 }
 
-type InboundMessage = InitMessage | WriteMessage | ResizeMessage | DisposeMessage;
+/**
+ * Seeds the worker's parser/buffer state from a previously serialized
+ * snapshot. Applied WITHOUT a flush so the hydrated cursor/modes/active-buffer
+ * aren't clobbered when the next `write` produces the first real flush.
+ *
+ * Grid `cellData` and `wrapFlags` are OPTIONAL. Omit them when the main
+ * thread has already applied cells directly to the SAB (constructor
+ * initialState path, where the worker hasn't started yet and can't race).
+ * Include them when applying post-construction in worker mode, so the grid
+ * write is serialized in the worker's message queue behind any pending
+ * `write`s — otherwise concurrent main-thread and worker writes would race
+ * against the shared buffer.
+ */
+interface SeedMessage {
+  type: "seed";
+  channelId?: string;
+  generation?: number;
+  cursor: { row: number; col: number; visible: boolean; style: string };
+  isAlternate: boolean;
+  modes: {
+    applicationCursorKeys: boolean;
+    bracketedPasteMode: boolean;
+    mouseProtocol: "none" | "x10" | "vt200" | "drag" | "any";
+    mouseEncoding: "default" | "sgr";
+    sendFocusEvents: boolean;
+  };
+  /** Full-format active-grid cell data (Transferable). */
+  cellData?: ArrayBuffer;
+  /** Per-row wrap flags as Int32 (Transferable). */
+  wrapFlags?: ArrayBuffer;
+}
+
+type InboundMessage = InitMessage | WriteMessage | ResizeMessage | DisposeMessage | SeedMessage;
 
 /** Messages the worker posts back to the main thread. */
 export interface FlushMessage {
@@ -150,6 +182,51 @@ function createBufferAndParser(
     usingSAB: sharedBuffer !== undefined,
     generation,
   };
+}
+
+/**
+ * Apply a hydrated snapshot to an existing channel without producing a flush.
+ * Seeds cursor, parser modes, and active buffer — and, if supplied, the grid
+ * cell data. Running in the worker's single-threaded message loop means any
+ * pending `write` completes before this applies, so grid writes can't race.
+ */
+function applySeed(ch: ChannelState, msg: SeedMessage): void {
+  const active = msg.isAlternate ? ch.bufferSet.alternate : ch.bufferSet.normal;
+  ch.bufferSet.setActive(msg.isAlternate);
+
+  // Grid payload (optional). Applied to the now-active grid.
+  if (msg.cellData) {
+    const grid = active.grid;
+    const cellView = new Uint32Array(msg.cellData);
+    if (cellView.length === grid.data.length) {
+      grid.rowOffsetData[0] = 0;
+      grid.data.set(cellView);
+      if (msg.wrapFlags) {
+        const wrapView = new Int32Array(msg.wrapFlags);
+        if (wrapView.length === grid.wrapFlags.length) {
+          grid.wrapFlags.set(wrapView);
+        }
+      }
+      grid.markAllDirty();
+    }
+  }
+
+  active.cursor.row = Math.max(0, Math.min(msg.cursor.row, ch.bufferSet.rows - 1));
+  active.cursor.col = Math.max(0, Math.min(msg.cursor.col, ch.bufferSet.cols - 1));
+  active.cursor.visible = msg.cursor.visible;
+  active.cursor.style = msg.cursor.style as "block" | "underline" | "bar";
+  active.cursor.wrapPending = false;
+  active.grid.setCursor(
+    active.cursor.row,
+    active.cursor.col,
+    active.cursor.visible,
+    active.cursor.style,
+  );
+  ch.parser.applicationCursorKeys = msg.modes.applicationCursorKeys;
+  ch.parser.bracketedPasteMode = msg.modes.bracketedPasteMode;
+  ch.parser.mouseProtocol = msg.modes.mouseProtocol;
+  ch.parser.mouseEncoding = msg.modes.mouseEncoding;
+  ch.parser.sendFocusEvents = msg.modes.sendFocusEvents;
 }
 
 function buildFlush(ch: ChannelState, bytesProcessed: number, channelId?: string): FlushMessage {
@@ -282,6 +359,22 @@ function handleMessage(msg: InboundMessage): void {
       break;
     }
 
+    case "seed": {
+      if (!parser || !bufferSet) {
+        postError("Worker not initialised — ignoring seed");
+        return;
+      }
+      const ch = { bufferSet, parser, usingSAB, generation: undefined };
+      applySeed(ch, msg);
+      // Post a flush so:
+      //   - non-SAB mode: worker-owned cell data reaches the main-thread grid
+      //   - any pre-seed write flushes are naturally superseded (this flush
+      //     arrives after them in FIFO order and carries post-seed state)
+      const flush = buildFlush(ch, 0);
+      postFlush(flush, usingSAB);
+      break;
+    }
+
     case "dispose": {
       bufferSet = null;
       parser = null;
@@ -360,6 +453,25 @@ function handleChannelMessage(msg: InboundMessage, channelId: string): void {
       }
       const flush = buildFlush(newCh, 0, channelId);
       postFlush(flush, newCh.usingSAB);
+      break;
+    }
+
+    case "seed": {
+      const ch = channels.get(channelId);
+      if (!ch) {
+        postError(
+          `Channel "${channelId}" not initialised — ignoring seed`,
+          channelId,
+          msg.generation,
+        );
+        return;
+      }
+      if (msg.generation !== undefined && msg.generation !== ch.generation) return;
+      applySeed(ch, msg);
+      // Flush so non-SAB cell data reaches main and any in-flight pre-seed
+      // write flushes get naturally superseded (FIFO convergence).
+      const flush = buildFlush(ch, 0, channelId);
+      postFlush(flush, ch.usingSAB);
       break;
     }
 

--- a/packages/web/src/parser-worker.ts
+++ b/packages/web/src/parser-worker.ts
@@ -13,6 +13,7 @@
  */
 
 import { BufferSet, VTParser } from "@next_term/core";
+import type { SeedMessage } from "./seed-message.js";
 
 // Type declaration for Web Worker global scope (not included in DOM lib)
 declare type DedicatedWorkerGlobalScope = typeof globalThis & {
@@ -67,38 +68,6 @@ interface DisposeMessage {
   type: "dispose";
   channelId?: string;
   generation?: number;
-}
-
-/**
- * Seeds the worker's parser/buffer state from a previously serialized
- * snapshot. Applied WITHOUT a flush so the hydrated cursor/modes/active-buffer
- * aren't clobbered when the next `write` produces the first real flush.
- *
- * Grid `cellData` and `wrapFlags` are OPTIONAL. Omit them when the main
- * thread has already applied cells directly to the SAB (constructor
- * initialState path, where the worker hasn't started yet and can't race).
- * Include them when applying post-construction in worker mode, so the grid
- * write is serialized in the worker's message queue behind any pending
- * `write`s — otherwise concurrent main-thread and worker writes would race
- * against the shared buffer.
- */
-interface SeedMessage {
-  type: "seed";
-  channelId?: string;
-  generation?: number;
-  cursor: { row: number; col: number; visible: boolean; style: string };
-  isAlternate: boolean;
-  modes: {
-    applicationCursorKeys: boolean;
-    bracketedPasteMode: boolean;
-    mouseProtocol: "none" | "x10" | "vt200" | "drag" | "any";
-    mouseEncoding: "default" | "sgr";
-    sendFocusEvents: boolean;
-  };
-  /** Full-format active-grid cell data (Transferable). */
-  cellData?: ArrayBuffer;
-  /** Per-row wrap flags as Int32 (Transferable). */
-  wrapFlags?: ArrayBuffer;
 }
 
 type InboundMessage = InitMessage | WriteMessage | ResizeMessage | DisposeMessage | SeedMessage;
@@ -214,7 +183,7 @@ function applySeed(ch: ChannelState, msg: SeedMessage): void {
   active.cursor.row = Math.max(0, Math.min(msg.cursor.row, ch.bufferSet.rows - 1));
   active.cursor.col = Math.max(0, Math.min(msg.cursor.col, ch.bufferSet.cols - 1));
   active.cursor.visible = msg.cursor.visible;
-  active.cursor.style = msg.cursor.style as "block" | "underline" | "bar";
+  active.cursor.style = msg.cursor.style;
   active.cursor.wrapPending = false;
   active.grid.setCursor(
     active.cursor.row,

--- a/packages/web/src/seed-message.ts
+++ b/packages/web/src/seed-message.ts
@@ -1,0 +1,72 @@
+/**
+ * SeedMessage type + helper, split out of `parser-worker.ts` so the
+ * main-thread bridges (`worker-bridge.ts`, `parser-pool.ts`) can import the
+ * builder without dragging the worker's `self`-referencing bootstrap into
+ * non-worker contexts (tests / Node / SSR).
+ */
+
+import type { ParserModeState } from "@next_term/core";
+
+/**
+ * Seeds the worker's parser/buffer state from a previously serialized
+ * snapshot. Applied WITHOUT a flush so the hydrated cursor/modes/active-buffer
+ * aren't clobbered when the next `write` produces the first real flush.
+ *
+ * Grid `cellData` and `wrapFlags` are OPTIONAL. Omit them when the main
+ * thread has already applied cells directly to the SAB (constructor
+ * initialState path, where the worker hasn't started yet and can't race).
+ * Include them when applying post-construction in worker mode, so the grid
+ * write is serialized in the worker's message queue behind any pending
+ * `write`s — otherwise concurrent main-thread and worker writes would race
+ * against the shared buffer.
+ */
+export interface SeedMessage {
+  type: "seed";
+  channelId?: string;
+  generation?: number;
+  cursor: {
+    row: number;
+    col: number;
+    visible: boolean;
+    style: "block" | "underline" | "bar";
+  };
+  isAlternate: boolean;
+  modes: ParserModeState;
+  /** Full-format active-grid cell data (Transferable). */
+  cellData?: ArrayBuffer;
+  /** Per-row wrap flags as Int32 (Transferable). */
+  wrapFlags?: ArrayBuffer;
+}
+
+/** Cursor fragment carried in seed messages. Same shape on both sides. */
+export type SeedCursor = SeedMessage["cursor"];
+
+/**
+ * Build a `SeedMessage` plus its transferable list. Shared between
+ * `WorkerBridge.seed` and `ParserChannel.seed` so the two bridges produce
+ * byte-identical messages and the transferable bookkeeping lives in one place.
+ *
+ * `channelId` is included only when supplied (pool path); the single-bridge
+ * path omits the field so the message shape matches the legacy expectation.
+ */
+export function buildSeedMessage(
+  cursor: SeedCursor,
+  isAlternate: boolean,
+  modes: ParserModeState,
+  cellData?: ArrayBuffer,
+  wrapFlags?: ArrayBuffer,
+  channelId?: string,
+): { msg: SeedMessage; transferables: ArrayBuffer[] } {
+  const msg: SeedMessage = { type: "seed", cursor, isAlternate, modes };
+  if (channelId !== undefined) msg.channelId = channelId;
+  const transferables: ArrayBuffer[] = [];
+  if (cellData) {
+    msg.cellData = cellData;
+    transferables.push(cellData);
+  }
+  if (wrapFlags) {
+    msg.wrapFlags = wrapFlags;
+    transferables.push(wrapFlags);
+  }
+  return { msg, transferables };
+}

--- a/packages/web/src/web-terminal.ts
+++ b/packages/web/src/web-terminal.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_THEME,
   expandCompactRow,
   reflowRows,
+  SNAPSHOT_VERSION,
   VTParser,
 } from "@next_term/core";
 import { AccessibilityManager } from "./accessibility.js";
@@ -194,9 +195,6 @@ const DEFAULT_FONT_SIZE = 14;
 const DEFAULT_FONT_FAMILY = "'Menlo', 'DejaVu Sans Mono', 'Consolas', monospace";
 const DEFAULT_SCROLLBACK = 1000;
 
-/** Bumped when the `TerminalState` schema changes incompatibly. */
-const SNAPSHOT_VERSION = 1;
-
 // ---------------------------------------------------------------------------
 // WebTerminal
 // ---------------------------------------------------------------------------
@@ -318,7 +316,10 @@ export class WebTerminal {
     // accepted; rejected snapshots (bad version/dimensions/shape) leave the
     // fresh BufferSet intact and we skip the downstream steps.
     const initialStateAccepted =
-      options?.initialState !== undefined && this.applyStateToBufferSet(options.initialState);
+      options?.initialState !== undefined && this.validateSnapshot(options.initialState);
+    if (initialStateAccepted && options?.initialState) {
+      this.applyStateToBufferSet(options.initialState);
+    }
 
     // Create canvas element
     this.canvas = document.createElement("canvas");
@@ -1379,7 +1380,8 @@ export class WebTerminal {
       );
     } else {
       // Non-worker mode: write directly to the main-thread BufferSet.
-      if (!this.applyStateToBufferSet(state)) return;
+      // `state` was already validated at the top of `hydrate()`.
+      this.applyStateToBufferSet(state);
       this.setParserModes(state.parserModes);
     }
 
@@ -1466,10 +1468,10 @@ export class WebTerminal {
    * constructor's `initialState` option — where the worker hasn't started
    * yet and no race is possible — and by non-worker-mode `hydrate()`.
    * Worker-mode `hydrate()` routes cells through the worker instead.
+   *
+   * Precondition: caller has already validated `state` via `validateSnapshot`.
    */
-  private applyStateToBufferSet(state: TerminalState): boolean {
-    if (!this.validateSnapshot(state)) return false;
-
+  private applyStateToBufferSet(state: TerminalState): void {
     if (state.isAlternate !== this.bufferSet.isAlternate) {
       this.bufferSet.setActive(state.isAlternate);
     }
@@ -1496,7 +1498,6 @@ export class WebTerminal {
 
     this.applyScrollbackSnapshot(state);
     // pasteRow() marked each row dirty above — no need to mark again here.
-    return true;
   }
 
   onData(callback: (data: Uint8Array) => void): void {

--- a/packages/web/src/web-terminal.ts
+++ b/packages/web/src/web-terminal.ts
@@ -13,7 +13,7 @@
  * RenderBridge, leaving the main thread free for DOM event handling only.
  */
 
-import type { CursorState, MouseEncoding, MouseProtocol, RowData, Theme } from "@next_term/core";
+import type { CursorState, ParserModeState, RowData, TerminalState, Theme } from "@next_term/core";
 import {
   BufferSet,
   CELL_SIZE,
@@ -176,6 +176,12 @@ export interface WebTerminalOptions {
   onData?: (data: Uint8Array) => void;
   onResize?: (size: { cols: number; rows: number }) => void;
   onTitleChange?: (title: string) => void;
+  /**
+   * Snapshot produced by `WebTerminal.serialize()` on a previous terminal.
+   * Applied before the render loop / worker starts so the first frame shows
+   * the restored grid. Dimensions in the snapshot must match `cols`/`rows`.
+   */
+  initialState?: TerminalState;
 }
 
 // ---------------------------------------------------------------------------
@@ -187,6 +193,9 @@ const DEFAULT_ROWS = 24;
 const DEFAULT_FONT_SIZE = 14;
 const DEFAULT_FONT_FAMILY = "'Menlo', 'DejaVu Sans Mono', 'Consolas', monospace";
 const DEFAULT_SCROLLBACK = 1000;
+
+/** Bumped when the `TerminalState` schema changes incompatibly. */
+const SNAPSHOT_VERSION = 1;
 
 // ---------------------------------------------------------------------------
 // WebTerminal
@@ -301,6 +310,15 @@ export class WebTerminal {
 
     // Create core buffer set
     this.bufferSet = new BufferSet(cols, rows, scrollback);
+
+    // Apply grid/cursor/scrollback from an initial snapshot BEFORE the render
+    // worker / render loop read the SAB, so the first frame shows the restored
+    // content. Parser modes + worker seed happen later, after the InputHandler
+    // exists and the worker has been started — but ONLY if the snapshot was
+    // accepted; rejected snapshots (bad version/dimensions/shape) leave the
+    // fresh BufferSet intact and we skip the downstream steps.
+    const initialStateAccepted =
+      options?.initialState !== undefined && this.applyStateToBufferSet(options.initialState);
 
     // Create canvas element
     this.canvas = document.createElement("canvas");
@@ -438,9 +456,42 @@ export class WebTerminal {
     const { width, height } = this.renderer.getCellSize();
     this.inputHandler.attach(container, width, height);
 
+    // Apply parser modes from the initial snapshot now that InputHandler exists.
+    if (initialStateAccepted && options?.initialState) {
+      this.setParserModes(options.initialState.parserModes);
+    }
+
     // Set up parsing: worker mode or direct mode.
     if (this.useWorkerMode) {
       this.startWorkerMode(cols, rows, scrollback);
+      // Seed worker-side parser state so the first flush doesn't revert the
+      // hydrated cursor/modes/active-buffer to worker defaults. Posted after
+      // the init message, before any write, so the worker applies it to its
+      // just-created BufferSet/VTParser.
+      //
+      // Grid cells: in SAB mode, the worker's BufferSet wraps the SAME shared
+      // buffer the main thread already wrote to — skip cellData. In non-SAB
+      // fallback mode, the worker's grid is independent and would stay blank
+      // without explicit cell data, so include it.
+      if (initialStateAccepted && options?.initialState) {
+        const backend = this.parserChannel ?? this.workerBridge;
+        const s = options.initialState;
+        const isShared = this.bufferSet.active.grid.isShared;
+        const cellsBuf = isShared ? undefined : s.cells.slice().buffer;
+        const wrapBuf = isShared ? undefined : s.wrapFlags.slice().buffer;
+        backend?.seed(
+          {
+            row: s.cursor.row,
+            col: s.cursor.col,
+            visible: s.cursor.visible,
+            style: s.cursor.style,
+          },
+          s.isAlternate,
+          s.parserModes,
+          cellsBuf,
+          wrapBuf,
+        );
+      }
     } else {
       this.parser = new VTParser(this.bufferSet);
       // Wire up title change callback
@@ -1194,14 +1245,258 @@ export class WebTerminal {
    * In worker mode, parser modes are synced from the worker via flush
    * messages. Values reflect the most recent flush.
    */
-  getParserModes(): {
-    applicationCursorKeys: boolean;
-    bracketedPasteMode: boolean;
-    mouseProtocol: MouseProtocol;
-    mouseEncoding: MouseEncoding;
-    sendFocusEvents: boolean;
-  } {
+  getParserModes(): ParserModeState {
     return this.inputHandler.getModes();
+  }
+
+  /**
+   * Apply parser/input modes.
+   *
+   * Intended for save/restore scenarios — pair with `getParserModes()` or
+   * a `serialize()` snapshot. In worker mode, the authoritative parser
+   * state lives in the worker, so these values may be overwritten by the
+   * next flush. Callers relying on parser modes across a remount typically
+   * re-issue the relevant DECSET sequences (e.g. via a replayed snapshot).
+   */
+  setParserModes(modes: ParserModeState): void {
+    if (this.disposed) return;
+    this.inputHandler.setApplicationCursorKeys(modes.applicationCursorKeys);
+    this.inputHandler.setBracketedPasteMode(modes.bracketedPasteMode);
+    this.inputHandler.setMouseProtocol(modes.mouseProtocol);
+    this.inputHandler.setMouseEncoding(modes.mouseEncoding);
+    this.inputHandler.setSendFocusEvents(modes.sendFocusEvents);
+  }
+
+  /**
+   * Snapshot the active buffer's grid, cursor, scrollback, and parser modes
+   * for later restoration. Use with the `initialState` constructor option on
+   * a fresh terminal, or `hydrate()` on an existing one.
+   *
+   * Captures the ACTIVE buffer only (normal OR alternate). Inactive-buffer
+   * content is not preserved — callers that need full dual-buffer restore
+   * should maintain their own snapshot.
+   *
+   * In worker-mode terminals, scrollback accumulates in the parser worker
+   * and is NOT reachable from the main thread — the `scrollback` field will
+   * be empty in that mode. Deployments driving a server-side snapshot
+   * replay typically don't need it.
+   */
+  serialize(): TerminalState {
+    if (this.disposed) {
+      throw new Error("[WebTerminal] serialize() called after dispose()");
+    }
+    const grid = this.bufferSet.active.grid;
+    const cols = grid.cols;
+    const rows = grid.rows;
+    const rowLen = cols * CELL_SIZE;
+    const cells = new Uint32Array(rows * rowLen);
+    const wrapFlags = new Int32Array(rows);
+    for (let r = 0; r < rows; r++) {
+      grid.copyRowInto(r, cells.subarray(r * rowLen, (r + 1) * rowLen));
+      wrapFlags[r] = grid.isWrapped(r) ? 1 : 0;
+    }
+    const cursor = this.bufferSet.active.cursor;
+    // Deep-copy scrollback rows: when scrollback is full, BufferSet's
+    // borrowRowBuffer() recycles the about-to-be-evicted row for the next
+    // pushScrollback. Sharing refs would corrupt the snapshot on the next
+    // scroll. See `BufferSet.borrowRowBuffer` for the recycling logic.
+    return {
+      version: SNAPSHOT_VERSION,
+      cols,
+      rows,
+      cells,
+      wrapFlags,
+      cursor: {
+        row: cursor.row,
+        col: cursor.col,
+        visible: cursor.visible,
+        style: cursor.style,
+      },
+      scrollback: {
+        rows: this.bufferSet.scrollback.map((r) => new Uint32Array(r)),
+        wrap: this.bufferSet.scrollbackWrap.slice(),
+        compact: this.bufferSet.scrollbackCompact.slice(),
+      },
+      parserModes: this.getParserModes(),
+      isAlternate: this.bufferSet.isAlternate,
+    };
+  }
+
+  /**
+   * Apply a serialized snapshot to this terminal. Dimensions must match
+   * the terminal's current `cols`/`rows`; otherwise this no-ops with a
+   * warning.
+   *
+   * Prefer the `initialState` constructor option when possible — it avoids
+   * a brief flash of the blank grid before content paints, and the work
+   * happens before the render worker / parser worker begin their loops.
+   *
+   * Worker-mode safety: the grid, cursor, modes, and active-buffer portion
+   * is posted to the parser worker so it's serialized behind any pending
+   * `write()` messages in the worker's queue. This means hydrate takes
+   * effect asynchronously in worker mode — subsequent `write()` calls on
+   * the same terminal still apply in order (FIFO postMessage), so callers
+   * don't need to await anything.
+   */
+  hydrate(state: TerminalState): void {
+    if (this.disposed) return;
+    if (!this.validateSnapshot(state)) return;
+
+    const backend = this.parserChannel ?? this.workerBridge;
+    if (backend) {
+      // Worker mode: route cells + cursor + modes + isAlternate through the
+      // worker so its in-flight writes don't race our grid writes.
+      // Scrollback, viewport, parser-mode mirror, and render rebind happen
+      // on the main thread — none of those touch the shared cell buffer.
+      this.applyScrollbackSnapshot(state);
+      this.setParserModes(state.parserModes);
+      // Keep the main-thread cursor + active-buffer flag in sync so queries
+      // like `activeCursor` / `isAlternateBuffer` return the expected value
+      // before the worker's async apply arrives back via flush.
+      if (state.isAlternate !== this.bufferSet.isAlternate) {
+        this.bufferSet.setActive(state.isAlternate);
+      }
+      const mainCursor = this.bufferSet.active.cursor;
+      mainCursor.row = Math.max(0, Math.min(state.cursor.row, state.rows - 1));
+      mainCursor.col = Math.max(0, Math.min(state.cursor.col, state.cols - 1));
+      mainCursor.visible = state.cursor.visible;
+      mainCursor.style = state.cursor.style;
+      mainCursor.wrapPending = false;
+      // Copy cells and wrap flags into detachable buffers the worker can own.
+      const cellsCopy = state.cells.slice().buffer;
+      const wrapCopy = state.wrapFlags.slice().buffer;
+      backend.seed(
+        {
+          row: state.cursor.row,
+          col: state.cursor.col,
+          visible: state.cursor.visible,
+          style: state.cursor.style,
+        },
+        state.isAlternate,
+        state.parserModes,
+        cellsCopy,
+        wrapCopy,
+      );
+    } else {
+      // Non-worker mode: write directly to the main-thread BufferSet.
+      if (!this.applyStateToBufferSet(state)) return;
+      this.setParserModes(state.parserModes);
+    }
+
+    // Clear scrollback viewport state so the hydrated live buffer is what
+    // renders (not a stale scrolled-back view).
+    this.viewportOffset = 0;
+    this.displayGrid = null;
+    this.updateScrollbar();
+
+    // Re-bind the render pipeline to the (possibly newly active) grid so it
+    // picks up the hydrated content.
+    const grid = this.bufferSet.active.grid;
+    const cursor = this.bufferSet.active.cursor;
+    if (this.sharedContext && this.paneId) {
+      this.sharedContext.updateTerminal(this.paneId, grid, cursor);
+    } else if (this.renderBridge) {
+      this.renderBridge.resize(grid.cols, grid.rows, grid.getBuffer() as SharedArrayBuffer);
+    } else {
+      this.renderer.attach(this.canvas, grid, cursor);
+    }
+    this.inputHandler.setGrid(grid);
+    this.accessibilityManager?.setGrid(grid, grid.rows, grid.cols);
+  }
+
+  /**
+   * Check version, dimensions, and structural shape of a snapshot. Emits a
+   * console warning describing which check failed. Used as a gate by both
+   * `hydrate()` and the constructor's `initialState` path before any state
+   * is mutated.
+   */
+  private validateSnapshot(state: TerminalState): boolean {
+    if (state.version !== SNAPSHOT_VERSION) {
+      console.warn(`[WebTerminal] snapshot: unsupported version ${state.version}`);
+      return false;
+    }
+    const cols = this.bufferSet.cols;
+    const rows = this.bufferSet.rows;
+    if (state.cols !== cols || state.rows !== rows) {
+      console.warn(
+        `[WebTerminal] snapshot: ${state.cols}x${state.rows} does not match terminal ${cols}x${rows}`,
+      );
+      return false;
+    }
+    const expectedCellLen = rows * cols * CELL_SIZE;
+    if (state.cells.length !== expectedCellLen || state.wrapFlags.length !== rows) {
+      console.warn(
+        `[WebTerminal] snapshot: malformed cells/wrapFlags (expected ${expectedCellLen} cells + ${rows} wrap flags, got ${state.cells.length}/${state.wrapFlags.length})`,
+      );
+      return false;
+    }
+    const sb = state.scrollback;
+    if (sb.rows.length !== sb.wrap.length || sb.rows.length !== sb.compact.length) {
+      console.warn(
+        `[WebTerminal] snapshot: scrollback arrays out of sync (rows=${sb.rows.length}, wrap=${sb.wrap.length}, compact=${sb.compact.length})`,
+      );
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Apply the main-thread-visible scrollback portion of a snapshot. The
+   * caller is responsible for having validated the snapshot already.
+   */
+  private applyScrollbackSnapshot(state: TerminalState): void {
+    this.bufferSet.scrollback.length = 0;
+    this.bufferSet.scrollbackWrap.length = 0;
+    this.bufferSet.scrollbackCompact.length = 0;
+    const sb = state.scrollback;
+    const maxSb = this.bufferSet.maxScrollback;
+    const sbAvail = sb.rows.length;
+    const sbLen = Math.min(sbAvail, maxSb);
+    const startIdx = sbAvail - sbLen;
+    for (let i = 0; i < sbLen; i++) {
+      this.bufferSet.scrollback.push(sb.rows[startIdx + i]);
+      this.bufferSet.scrollbackWrap.push(sb.wrap[startIdx + i]);
+      this.bufferSet.scrollbackCompact.push(sb.compact[startIdx + i]);
+    }
+  }
+
+  /**
+   * Internal: apply the full buffer-side portion of a snapshot (grid,
+   * cursor, scrollback, active-buffer flag) on the main thread. Used by the
+   * constructor's `initialState` option — where the worker hasn't started
+   * yet and no race is possible — and by non-worker-mode `hydrate()`.
+   * Worker-mode `hydrate()` routes cells through the worker instead.
+   */
+  private applyStateToBufferSet(state: TerminalState): boolean {
+    if (!this.validateSnapshot(state)) return false;
+
+    if (state.isAlternate !== this.bufferSet.isAlternate) {
+      this.bufferSet.setActive(state.isAlternate);
+    }
+
+    const grid = this.bufferSet.active.grid;
+    // Normalize the circular-buffer offset so physical rows equal logical rows
+    // for the paste that follows.
+    grid.rowOffsetData[0] = 0;
+    const cols = grid.cols;
+    const rows = grid.rows;
+    const rowLen = cols * CELL_SIZE;
+    for (let r = 0; r < rows; r++) {
+      const rowSlice = state.cells.subarray(r * rowLen, (r + 1) * rowLen);
+      grid.pasteRow(r, rowSlice, state.wrapFlags[r] !== 0);
+    }
+
+    const cursor = this.bufferSet.active.cursor;
+    cursor.row = Math.max(0, Math.min(state.cursor.row, rows - 1));
+    cursor.col = Math.max(0, Math.min(state.cursor.col, cols - 1));
+    cursor.visible = state.cursor.visible;
+    cursor.style = state.cursor.style;
+    cursor.wrapPending = false;
+    grid.setCursor(cursor.row, cursor.col, cursor.visible, cursor.style);
+
+    this.applyScrollbackSnapshot(state);
+    // pasteRow() marked each row dirty above — no need to mark again here.
+    return true;
   }
 
   onData(callback: (data: Uint8Array) => void): void {

--- a/packages/web/src/worker-bridge.ts
+++ b/packages/web/src/worker-bridge.ts
@@ -13,6 +13,7 @@
 import type { CursorState, ParserModeState } from "@next_term/core";
 import { CELL_SIZE, type CellGrid, modPositive } from "@next_term/core";
 import type { FlushMessage, OutboundMessage } from "./parser-worker.js";
+import { buildSeedMessage, type SeedCursor, type SeedMessage } from "./seed-message.js";
 
 // ---- Flow-control constants ------------------------------------------------
 
@@ -49,7 +50,7 @@ export class WorkerBridge {
    * seed replaces an earlier pending one — both represent complete snapshots,
    * so the latest intent wins.
    */
-  private pendingSeed: { msg: Record<string, unknown>; transferables: ArrayBuffer[] } | null = null;
+  private pendingSeed: { msg: SeedMessage; transferables: ArrayBuffer[] } | null = null;
   /** Skip cell data in pending non-SAB flushes (main thread already has reflowed data). */
   private skipFlushCellDataCount = 0;
 
@@ -173,30 +174,21 @@ export class WorkerBridge {
    * before the worker started.
    */
   seed(
-    cursor: { row: number; col: number; visible: boolean; style: string },
+    cursor: SeedCursor,
     isAlternate: boolean,
     modes: ParserModeState,
     cellData?: ArrayBuffer,
     wrapFlags?: ArrayBuffer,
   ): void {
     if (this.disposed || !this.worker) return;
-    const msg: Record<string, unknown> = { type: "seed", cursor, isAlternate, modes };
-    const transferables: ArrayBuffer[] = [];
-    if (cellData) {
-      msg.cellData = cellData;
-      transferables.push(cellData);
-    }
-    if (wrapFlags) {
-      msg.wrapFlags = wrapFlags;
-      transferables.push(wrapFlags);
-    }
+    const built = buildSeedMessage(cursor, isAlternate, modes, cellData, wrapFlags);
     // Preserve FIFO against locally-queued writes (writeQueue is only non-empty
     // while paused). A later seed supersedes an earlier pending one.
     if (this.writeQueue.length > 0) {
-      this.pendingSeed = { msg, transferables };
+      this.pendingSeed = built;
       return;
     }
-    this.worker.postMessage(msg, transferables);
+    this.worker.postMessage(built.msg, built.transferables);
   }
 
   /**

--- a/packages/web/src/worker-bridge.ts
+++ b/packages/web/src/worker-bridge.ts
@@ -10,7 +10,7 @@
  * when the PTY produces data faster than the worker can parse it.
  */
 
-import type { CursorState } from "@next_term/core";
+import type { CursorState, ParserModeState } from "@next_term/core";
 import { CELL_SIZE, type CellGrid, modPositive } from "@next_term/core";
 import type { FlushMessage, OutboundMessage } from "./parser-worker.js";
 
@@ -43,6 +43,13 @@ export class WorkerBridge {
   private paused = false;
   /** Buffered writes waiting to be sent while paused. */
   private writeQueue: Uint8Array[] = [];
+  /**
+   * Seed posted while writes are still queued locally. Held until the write
+   * queue drains so the worker sees writes before the seed (FIFO). A later
+   * seed replaces an earlier pending one — both represent complete snapshots,
+   * so the latest intent wins.
+   */
+  private pendingSeed: { msg: Record<string, unknown>; transferables: ArrayBuffer[] } | null = null;
   /** Skip cell data in pending non-SAB flushes (main thread already has reflowed data). */
   private skipFlushCellDataCount = 0;
 
@@ -158,6 +165,41 @@ export class WorkerBridge {
   }
 
   /**
+   * Seed the worker's cursor, parser modes, and active buffer from a snapshot.
+   * Does not produce a flush. When called after writes are in flight, supply
+   * `cellData`/`wrapFlags` so the grid update is serialized behind pending
+   * writes in the worker's message queue (avoiding SAB races). Omit them
+   * when the main thread has already applied cells directly to the SAB
+   * before the worker started.
+   */
+  seed(
+    cursor: { row: number; col: number; visible: boolean; style: string },
+    isAlternate: boolean,
+    modes: ParserModeState,
+    cellData?: ArrayBuffer,
+    wrapFlags?: ArrayBuffer,
+  ): void {
+    if (this.disposed || !this.worker) return;
+    const msg: Record<string, unknown> = { type: "seed", cursor, isAlternate, modes };
+    const transferables: ArrayBuffer[] = [];
+    if (cellData) {
+      msg.cellData = cellData;
+      transferables.push(cellData);
+    }
+    if (wrapFlags) {
+      msg.wrapFlags = wrapFlags;
+      transferables.push(wrapFlags);
+    }
+    // Preserve FIFO against locally-queued writes (writeQueue is only non-empty
+    // while paused). A later seed supersedes an earlier pending one.
+    if (this.writeQueue.length > 0) {
+      this.pendingSeed = { msg, transferables };
+      return;
+    }
+    this.worker.postMessage(msg, transferables);
+  }
+
+  /**
    * Tear down the worker.
    */
   dispose(): void {
@@ -173,6 +215,7 @@ export class WorkerBridge {
     }
 
     this.writeQueue.length = 0;
+    this.pendingSeed = null;
   }
 
   // ---- Getters for flow-control state (useful for testing) -----------------
@@ -238,6 +281,14 @@ export class WorkerBridge {
       const next = this.writeQueue.shift();
       if (!next) break;
       this.sendWrite(next);
+    }
+    // Post any seed that was deferred while the queue was backed up. Only
+    // once the queue is fully drained AND the worker isn't paused again
+    // (sendWrite can re-trip pause mid-drain).
+    if (this.pendingSeed && this.writeQueue.length === 0 && !this.paused && this.worker) {
+      const { msg, transferables } = this.pendingSeed;
+      this.pendingSeed = null;
+      this.worker.postMessage(msg, transferables);
     }
   };
 


### PR DESCRIPTION
## Summary

Adds save/restore (`serialize` / `hydrate` / `initialState`) for `WebTerminal` and surfaces it through the React component. The primary use case is **remount-without-flash**: when a layout change reparents the terminal (tab switch, split-pane drag, dialog open/close), capture state on the old instance and pass it as `initialState` to the new one so the first paint shows the restored grid.

## How it works

- **`WebTerminal#serialize()`** returns a versioned `TerminalState` snapshot of the active buffer, cursor, scrollback, parser modes, and alt-buffer flag. Scrollback rows are deep-copied to defend against `BufferSet.borrowRowBuffer()` recycling the about-to-be-evicted row.
- **`initialState` constructor option** applies the snapshot to `BufferSet` *before* the render worker / parser worker start, so the first frame shows the restored content (no blank flash).
- **`WebTerminal#hydrate(state)`** applies a snapshot to an already-mounted terminal. In worker mode, cells + cursor + modes are routed through the parser worker via a new `seed` message so they're serialized behind any in-flight `write()`s (FIFO). Main-thread state (scrollback, viewport offset, accessibility tree) is updated synchronously.
- **`pendingSeed` deferral** in `WorkerBridge` and `ParserChannel`: if a seed arrives while writes are queued under back-pressure, it's held until the queue drains so the worker can't apply the snapshot ahead of pending writes.
- **Validation** via `validateSnapshot()` checks version, dimensions, cell-data length, and scrollback array parity. Rejected snapshots no-op with `console.warn` and leave the terminal untouched. Single-gate model: `applyStateToBufferSet`'s precondition is "caller validated."

## Commits

```
d4d2944  refactor: simplify pass — co-locate version const, extract seed-message helper
e03c5ac  demo: add Save/Restore buttons to HUD for dogfooding terminal state API
e6f7ce0  docs(react,web): document save/restore API in package READMEs
7fcded4  feat(react): expose serialize/hydrate/setParserModes on TerminalHandle + initialState prop
a7311d5  feat(web): WebTerminal.serialize / hydrate / initialState + worker seed protocol
c9234cd  feat(core): add TerminalState and ParserModeState types
```

## Test coverage

28 new tests, all green; 1,868 / 1,868 total suite.

- **`terminal-state.test.ts` (22)** — roundtrip, scrollback recycle defense, version/dimension/shape validation, viewport reset, alt-buffer, write-after-hydrate, scrollback truncation to smaller `maxScrollback`, wide-char (CJK) roundtrip, disposed guards, worker-mode SAB vs non-SAB seed dispatch.
- **`terminal-hydrate.test.ts` (3)** — `<Terminal>` ref methods round-trip; `serialize()` throws after unmount; `initialState` prop restores text before first paint.
- **`worker-bridge.test.ts` (+3)** — `seed` without `cellData`, `seed` with transferables, deferred-on-pause FIFO.
- **`parser-pool.test.ts` (+3)** — same three cases on the `ParserChannel` path so multi-pane consumers are covered.

## Performance verification

Ran `pnpm --filter @next_term/bench bench` on both branches. All 24 parser scenarios are within ±1.5% delta where the relative margin of error is below the delta. Three scenarios show larger apparent deltas but all have RME exceeding the delta (e.g. `ascii: -10.25%` with `rme=140%`), so they're measurement noise, not regressions. The `perf-regression.test.ts` floor checks (in-suite) also pass.

The new code adds no hot-path work: the steady-state additions are one `case "seed":` in two switch statements (V8 jump table) and a single `null` check after `drainQueue`'s loop (runs once per resume-from-pause, not per write).

## Pre-flight checks

- ✅ Tests: 1,868 / 1,868 pass
- ✅ TypeScript: `tsc -b` clean
- ✅ Lint: `biome check packages/` clean
- ✅ Build: 7 packages succeed
- ✅ Security review: no vulnerabilities (cells + parserModes flow into typed-array buffers and primitive flags, never into a string sink that's interpreted as code or queries; demo uses `JSON.parse`/`JSON.stringify` of named fields — no prototype-pollution sink)
- ✅ Simplify pass: 5 fixes applied (co-located `SNAPSHOT_VERSION`, tightened `SeedMessage` types, extracted `buildSeedMessage` helper, single-gate `validateSnapshot`, trimmed demo comment); −49 LOC net

## Possible follow-ups (not in this PR)

- `BufferSet.clearScrollback` / `replaceScrollback` helpers to contain the `applyScrollbackSnapshot` coupling to the array representation.
- `CellGrid.copyRowInto` to use `dest.set(this.data.subarray(...))` for marginal serialize() speedup.
- Options-object `seed(opts: SeedOptions)` signature (deferred because the current change is the smallest one that doesn't force test changes).
- `validateSnapshot` returning a discriminated `{ok, reason}` so callers can surface "snapshot was 80×24, terminal is now 100×30" instead of console-warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
